### PR TITLE
Feature/pivotcholesky

### DIFF
--- a/docs/benchmarks/benchmarks.rst
+++ b/docs/benchmarks/benchmarks.rst
@@ -10,12 +10,13 @@ Benchmarks
    tsunami
    mcmc_benchmark
    mice_benchmark
+   pivot_benchmark
    gkdr_benchmark
    histmatch_benchmark
 
 The code includes a series of benchmarks that illustrate various pieces of the implementation. Benchmarks
 can be run from the ``mogp_emulator/tests`` directory by entering ``make all`` or ``make benchmarks`` to
-run all benchmarks, or ``make rosenbrock``, ``make branin``, ``make tsunami``, ``make mcmc``, ``make mice``, ``make gKDR``, or ``make histmatch`` to run the individual benchmarks.
+run all benchmarks, or ``make rosenbrock``, ``make branin``, ``make tsunami``, ``make mcmc``, ``make pivot``, ``make mice``, ``make gKDR``, or ``make histmatch`` to run the individual benchmarks.
 
 Single Emulator Convergence Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,6 +62,14 @@ A benchmark comparing the MICE Sequential design method to Latin Hypercube sampl
 This creates designs of a variety of sizes and computes the error on unseen data for the 2D Branin
 function. It compares the accuracy of the sequential design to the Latin Hypercube for both the
 predictions and uncertainties.
+
+Pivoted Cholesky Benchmark
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A benchmark shows how a duplicated input can degrade emulator performance
+and how using pivoting can fix this more effectively than adding a nugget.
+It compares the accuracy of the emulator and its uncertainty for pivoting
+and adaptive nugget handling to the 2D Branin function.
 
 Dimension Reduction Benchmark
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/benchmarks/pivot_benchmark.rst
+++ b/docs/benchmarks/pivot_benchmark.rst
@@ -1,0 +1,7 @@
+.. _pivot_benchmark:
+
+**********************************
+Pivoted Cholesky Benchmark
+**********************************
+
+.. automodule:: mogp_emulator.benchmarks.benchmark_pivot

--- a/docs/implementation/implementation.rst
+++ b/docs/implementation/implementation.rst
@@ -19,3 +19,4 @@ mogp_emulator Implementation Details
    SequentialDesign
    HistoryMatching
    MCMC
+   linalg

--- a/docs/implementation/linalg.rst
+++ b/docs/implementation/linalg.rst
@@ -1,0 +1,8 @@
+.. _linalg:
+
+**********************************
+The ``linalg`` Module
+**********************************
+
+.. automodule:: mogp_emulator.linalg.cholesky
+    :members:

--- a/mogp_emulator/GaussianProcess.py
+++ b/mogp_emulator/GaussianProcess.py
@@ -7,38 +7,47 @@ from scipy.optimize import OptimizeResult
 from mogp_emulator.linalg import jit_cholesky, pivot_cholesky, pivot_transpose
 
 class GaussianProcess(object):
-    """
-    Implementation of a Gaussian Process Emulator.
+    """Implementation of a Gaussian Process Emulator.
 
-    This class provides a representation of a Gaussian Process Emulator. It contains
-    methods for fitting the GP to a given set of hyperparameters, computing the
-    negative log marginal likelihood plus prior (so negative log posterior) and its
-    derivatives, and making predictions on unseen data. Note that routines to
-    estimate hyperparameters are not included in the class definition, and are instead
-    provided externally to facilitate implementation of high performance versions.
+    This class provides a representation of a Gaussian Process
+    Emulator. It contains methods for fitting the GP to a given set of
+    hyperparameters, computing the negative log marginal likelihood
+    plus prior (so negative log posterior) and its derivatives, and
+    making predictions on unseen data. Note that routines to estimate
+    hyperparameters are not included in the class definition, and are
+    instead provided externally to facilitate implementation of high
+    performance versions.
 
-    The required arguments to initialize a GP is a set of training data consisting
-    of the inputs and targets for each of those inputs. These must be numpy arrays
-    whose first axis is of the same length. Targets must be a 1D array, while inputs
-    can be 2D or 1D. If inputs is 1D, then it is assumed that the length of the second
-    axis is unity.
+    The required arguments to initialize a GP is a set of training
+    data consisting of the inputs and targets for each of those
+    inputs. These must be numpy arrays whose first axis is of the same
+    length. Targets must be a 1D array, while inputs can be 2D or
+    1D. If inputs is 1D, then it is assumed that the length of the
+    second axis is unity.
 
-    Optional arguments are the particular mean function to use (default is zero mean),
-    the covariance kernel to use (default is the squared exponential covariance),
-    a list of prior distributions for each hyperparameter (default is no prior information
-    on any hyperparameters) and the method for handling the nugget parameter.
-    The nugget is additional "noise" that is added to the diagonal of the covariance
-    kernel as a variance. This nugget can represent uncertainty in the target values
-    themselves, or simply be used to stabilize the numerical inversion of the covariance
-    matrix. The nugget can be fixed (a non-negative float), can be found adaptively
-    (by passing the string ``"adaptive"`` to make the noise only as large as necessary
-    to successfully invert the covariance matrix), or can be fit as a hyperparameter
-    (by passing the string ``"fit"``).
+    Optional arguments are the particular mean function to use
+    (default is zero mean), the covariance kernel to use (default is
+    the squared exponential covariance), a list of prior distributions
+    for each hyperparameter (default is no prior information on any
+    hyperparameters) and the method for handling the nugget parameter.
+    The nugget is additional "noise" that is added to the diagonal of
+    the covariance kernel as a variance. This nugget can represent
+    uncertainty in the target values themselves, or simply be used to
+    stabilize the numerical inversion of the covariance matrix. The
+    nugget can be fixed (a non-negative float), can be found
+    adaptively (by passing the string ``"adaptive"`` to make the noise
+    only as large as necessary to successfully invert the covariance
+    matrix), can be fit as a hyperparameter (by passing the string
+    ``"fit"``), or pivoting can be used to ignore any collinear matrix
+    rows and ensure a zero nugget is used (by passing the string
+    ``"pivot"``).
 
-    The internal emulator structure involves arrays for the inputs, targets, and hyperparameters.
-    Other useful information are the number of training examples ``n``, the number of input
-    parameters ``D``, and the number of hyperparameters ``n_params``. These parameters can
-    be obtained externally by accessing these attributes
+    The internal emulator structure involves arrays for the inputs,
+    targets, and hyperparameters.  Other useful information are the
+    number of training examples ``n``, the number of input parameters
+    ``D``, and the number of hyperparameters ``n_params``. These
+    parameters can be obtained externally by accessing these
+    attributes
 
     Example: ::
 
@@ -65,68 +74,92 @@ class GaussianProcess(object):
     """
     def __init__(self, inputs, targets, mean=None, kernel=SquaredExponential(), priors=None,
                  nugget="adaptive", inputdict = {}, use_patsy=True):
-        """
-        Create a new GaussianProcess Emulator
+        """Create a new GaussianProcess Emulator
 
-        Creates a new GaussianProcess Emulator from either the input data and targets to be fit and
-        optionally a mean function, covariance kernel, and nugget parameter/method.
+        Creates a new GaussianProcess Emulator from either the input
+        data and targets to be fit and optionally a mean function,
+        covariance kernel, and nugget parameter/method.
 
-        Required arguments are numpy arrays ``inputs`` and ``targets``, described below.
-        Additional arguments are ``mean`` to specify the mean function (default is
-        ``None`` for zero mean), ``kernel`` to specify the covariance kernel (default
-        is the squared exponential kernel), ``priors`` to indicate prior distributions
-        on the hyperparameters, and ``nugget`` to specify how the nugget
-        parameter is handled (see below; default is to fit the nugget adaptively).
+        Required arguments are numpy arrays ``inputs`` and
+        ``targets``, described below.  Additional arguments are
+        ``mean`` to specify the mean function (default is ``None`` for
+        zero mean), ``kernel`` to specify the covariance kernel
+        (default is the squared exponential kernel), ``priors`` to
+        indicate prior distributions on the hyperparameters, and
+        ``nugget`` to specify how the nugget parameter is handled (see
+        below; default is to fit the nugget adaptively).
 
-        ``inputs`` is a 2D array-like object holding the input data, whose shape is
-        ``n`` by ``D``, where ``n`` is the number of training examples to be fit and ``D``
-        is the number of input variables to each simulation. If ``inputs`` is a 1D array,
-        it is assumed that ``D = 1``.
+        ``inputs`` is a 2D array-like object holding the input data,
+        whose shape is ``n`` by ``D``, where ``n`` is the number of
+        training examples to be fit and ``D`` is the number of input
+        variables to each simulation. If ``inputs`` is a 1D array, it
+        is assumed that ``D = 1``.
 
-        ``targets`` is the target data to be fit by the emulator, also held in an array-like
-        object. This must be a 1D array of length ``n``.
+        ``targets`` is the target data to be fit by the emulator, also
+        held in an array-like object. This must be a 1D array of
+        length ``n``.
 
-        ``prior`` must be a list of length ``n_params`` whose elements are either ``Prior``-derived
-        objects or ``None``.  Each element is used as the prior for the corresponding parameter (with
-        ``None`` indicating an uninformative prior).  Passing the empty list or ``None`` as this
-        argument (in its entirety) may be used as an abbreviation for a list of ``n_params`` where
-        all list elements are ``None``.
+        ``prior`` must be a list of length ``n_params`` whose elements
+        are either ``Prior``-derived objects or ``None``.  Each
+        element is used as the prior for the corresponding parameter
+        (with ``None`` indicating an uninformative prior).  Passing
+        the empty list or ``None`` as this argument (in its entirety)
+        may be used as an abbreviation for a list of ``n_params``
+        where all list elements are ``None``.
 
-        ``nugget`` controls how additional noise is added to the emulator targets when fitting.
-        This can be specified in several ways. If a string is provided, it can take the
-        values of ``"adaptive"`` or ``"fit"``, which indicate that the nugget will be
-        chosen in the fitting process. ``"adaptive"`` means that the nugget will be made only
-        as large as necessary to invert the covariance matrix, while ``"fit"`` means that
-        the nugget will be treated as a hyperparameter to be optimized. Alternatively,
-        a non-negative float can be used to specify a fixed noise level. If no value is
-        specified for the ``nugget`` parameter, ``"adaptive"`` is the default.
+        ``nugget`` controls how additional noise is added to the
+        emulator targets when fitting.  This can be specified in
+        several ways. If a string is provided, it can take the values
+        of ``"adaptive"`` or ``"fit"``, which indicate that the nugget
+        will be chosen in the fitting process. The nugget can also be
+        chosen as part of the fitting process, with three options for
+        nugget handling: ``"adaptive"`` means that the nugget will be
+        made only as large as necessary to invert the covariance
+        matrix, ``"fit"`` means that the nugget will be treated as a
+        hyperparameter to be optimized, and ``"pivot"`` indicates that
+        pivoting will be used to ignore any collinear rows and ensure
+        use of a nugget of zero. Alternatively, a non-negative float
+        can be used to specify a fixed noise level. If no value is
+        specified for the ``nugget`` parameter, ``"adaptive"`` is the
+        default.
 
 
-        :param inputs: Numpy array holding emulator input parameters. Must be 1D with length
-                       ``n`` or 2D with shape ``n`` by ``D``, where ``n`` is the number of
-                       training examples and ``D`` is the number of input parameters for
-                       each output.
-        :type inputs: ndarray
-        :param targets: Numpy array holding emulator targets. Must be 1D with length ``n``
+        :param inputs: Numpy array holding emulator input
+                       parameters. Must be 1D with length ``n`` or 2D
+                       with shape ``n`` by ``D``, where ``n`` is the
+                       number of training examples and ``D`` is the
+                       number of input parameters for each output.
+                       :type inputs: ndarray
+        :param targets: Numpy array holding emulator targets. Must be
+                        1D with length ``n``
         :type targets: ndarray
-        :param mean: Mean function to be used (optional, default is ``None`` for a zero mean)
+        :param mean: Mean function to be used (optional, default is
+                     ``None`` for a zero mean)
         :type mean: None or MeanFunction
-        :param kernel: Covariance kernel to be used (optional, default is Squared Exponential)
-                       Can provide either a ``Kernel`` object or a string matching the
-                       kernel type to be used.
+        :param kernel: Covariance kernel to be used (optional, default
+                     is Squared Exponential) Can provide either a
+                     ``Kernel`` object or a string matching the kernel
+                     type to be used.
         :type kernel: Kernel or str
-        :param priors: List of priors to be used. Must be None (default) or an empty list
-                       (indicates uninformative priors) or list of length ``n_params``.
-                       Any parameter for which you wish to specify an uninformative prior,
-                       pass ``None``. Number of parameters is the number of parameters in
-                       the mean function plus ``D + 2`` (one correlation length per input
-                       plus a covariance scale and a nugget). If the nugget will not be fit,
-                       the list can have length ``n_params - 1``.
+        :param priors: List of priors to be used. Must be None
+                     (default) or an empty list (indicates
+                     uninformative priors) or list of length
+                     ``n_params``.  Any parameter for which you wish
+                     to specify an uninformative prior, pass
+                     ``None``. Number of parameters is the number of
+                     parameters in the mean function plus ``D + 2``
+                     (one correlation length per input plus a
+                     covariance scale and a nugget). If the nugget
+                     will not be fit, the list can have length
+                     ``n_params - 1``.
         :type priors: list or None
-        :param nugget: Noise to be added to the diagonal, specified as a string or a float.
-                       A non-negative float specifies the noise level explicitly, while a string
-                       indicates that the nugget will be found via fitting, either as ``"adaptive"``
-                       or ``"fit"`` (see above for a description). Default is ``"adaptive"``.
+        :param nugget: Noise to be added to the diagonal, specified as
+                     a string or a float.  A non-negative float
+                     specifies the noise level explicitly, while a
+                     string indicates that the nugget will be found
+                     via fitting, either as ``"adaptive"``, ``"fit"``,
+                     or ``"pivot"`` (see above for a
+                     description). Default is ``"adaptive"``.
         :type nugget: float or str
         :returns: New ``GaussianProcess`` instance
         :rtype: GaussianProcess
@@ -216,63 +249,73 @@ class GaussianProcess(object):
 
     @property
     def n_params(self):
-        """
-        Returns number of hyperparameters
+        """Returns number of hyperparameters
 
-        Returns the number of hyperparameters for the emulator. The number depends on the
-        choice of mean function, covariance function, and nugget strategy, and possibly the
-        number of inputs for certain choices of the mean function.
+        Returns the number of hyperparameters for the emulator. The
+        number depends on the choice of mean function, covariance
+        function, and nugget strategy, and possibly the number of
+        inputs for certain choices of the mean function.
 
         :returns: Number of hyperparameters
         :rtype: int
+
         """
 
         return self.mean.get_n_params(self.inputs) + self.D + 2
 
     @property
     def nugget_type(self):
-        """
-        Returns method used to select nugget parameter
+        """Returns method used to select nugget parameter
 
-        Returns a string indicating how the nugget parameter is treated, either ``"adaptive"``,
-        ``"pivot"``, ``"fit"``, or ``"fixed"``. This is automatically set when changing the ``nugget``
-        property.
+        Returns a string indicating how the nugget parameter is
+        treated, either ``"adaptive"``, ``"pivot"``, ``"fit"``, or
+        ``"fixed"``. This is automatically set when changing the
+        ``nugget`` property.
 
         :returns: Current nugget fitting method
         :rtype: str
+
         """
         return self._nugget_type
 
     @property
     def nugget(self):
-        """
-        Returns emulator nugget parameter
+        """Returns emulator nugget parameter
 
-        Returns current value of the nugget parameter. If the nugget is to be selected
-        adaptively, by pivoting,  or by fitting the emulator and the nugget has not been fit,
-        returns ``None``.
+        Returns current value of the nugget parameter. If the nugget
+        is to be selected adaptively, by pivoting, or by fitting the
+        emulator and the nugget has not been fit, returns ``None``.
 
         :returns: Current nugget value, either a float or ``None``
         :rtype: float or None
 
-        The ``nugget`` parameter controls how noise is added to the covariance matrix in order to
-        stabilize the inversion or smooth the emulator predictions. If ``nugget`` is a non-negative
-        float, then that particular value is used for the nugget. Note that setting this parameter
-        to be zero enforces that the emulator strictly interpolates between points. Alternatively,
-        a string can be provided. A value of ``"fit"`` means that the nugget is treated as a
-        hyperparameter, and is the last entry in the ``theta`` array. Alternatively, if ``nugget``
-        is set to be ``"adaptive"``, the fitting routine will adaptively make the noise parameter
-        as large as is needed to ensure that the emulator can be fit. Finally,
-        pivoting can be selected by setting to ``"pivot"``, which will ignore any
-        collinear rows in the covariance matrix.
+        The ``nugget`` parameter controls how noise is added to the
+        covariance matrix in order to stabilize the inversion or
+        smooth the emulator predictions. If ``nugget`` is a
+        non-negative float, then that particular value is used for the
+        nugget. Note that setting this parameter to be zero enforces
+        that the emulator strictly interpolates between
+        points. Alternatively, a string can be provided. A value of
+        ``"fit"`` means that the nugget is treated as a
+        hyperparameter, and is the last entry in the ``theta``
+        array. Alternatively, if ``nugget`` is set to be
+        ``"adaptive"``, the fitting routine will adaptively make the
+        noise parameter as large as is needed to ensure that the
+        emulator can be fit. Finally, pivoting can be selected by
+        setting to ``"pivot"``, which will ignore any collinear rows
+        in the covariance matrix.
 
-        Internally, this modifies both the way the nugget is chosen (which can be determined
-        via the ``nugget_type`` property) and the value itself (the ``nugget`` property)
+        Internally, this modifies both the way the nugget is chosen
+        (which can be determined via the ``nugget_type`` property) and
+        the value itself (the ``nugget`` property)
 
-        :param nugget: Noise to be added to the diagonal, specified as a string or a float.
-                       A non-negative float specifies the noise level explicitly, while a string
-                       indicates that the nugget will be found via fitting, either as ``"adaptive"``,
-                       ``"pivot"``, or ``"fit"`` (see above for a description).
+        :param nugget: Noise to be added to the diagonal, specified as
+                       a string or a float.  A non-negative float
+                       specifies the noise level explicitly, while a
+                       string indicates that the nugget will be found
+                       via fitting, either as ``"adaptive"``,
+                       ``"pivot"``, or ``"fit"`` (see above for a
+                       description).
         :type nugget: float or str
         :returns: None
         :rtype: None
@@ -335,31 +378,37 @@ class GaussianProcess(object):
 
     @property
     def theta(self):
-        """
-        Returns emulator hyperparameters
+        """Returns emulator hyperparameters
 
-        Returns current hyperparameters for the emulator as a numpy array if they have been fit.
-        If no parameters have been fit, returns ``None``. Note that the number of parameters
-        depends on the mean function, so the length of this array will vary across instances.
+        Returns current hyperparameters for the emulator as a numpy
+        array if they have been fit.  If no parameters have been fit,
+        returns ``None``. Note that the number of parameters depends
+        on the mean function, so the length of this array will vary
+        across instances.
 
-        :returns: Current parameter values (numpy array of length ``n_params``), or ``None`` if the
-                  parameters have not been fit.
+        :returns: Current parameter values (numpy array of length
+                  ``n_params``), or ``None`` if the parameters have
+                  not been fit.
         :rtype: ndarray or None
 
-        When set, pre-calculates the matrices needed to compute the log-likelihood and its derivatives
-        and make subsequent predictions. This is called any time the hyperparameter values are
-        changed in order to ensure that all the information is needed to evaluate the
-        log-likelihood and its derivatives, which are needed when fitting the optimal
-        hyperparameters.
+        When set, pre-calculates the matrices needed to compute the
+        log-likelihood and its derivatives and make subsequent
+        predictions. This is called any time the hyperparameter values
+        are changed in order to ensure that all the information is
+        needed to evaluate the log-likelihood and its derivatives,
+        which are needed when fitting the optimal hyperparameters.
 
-        The method computes the mean function and covariance matrix and inverts the covariance
-        matrix using the method specified by the value of ``nugget``. The factorized matrix
-        and the product of the inverse with the difference between the targets and the mean
-        are cached for later use, and the negative marginal log-likelihood is also cached.
-        This method has no return value, but it does modify the state of the object.
+        The method computes the mean function and covariance matrix
+        and inverts the covariance matrix using the method specified
+        by the value of ``nugget``. The factorized matrix and the
+        product of the inverse with the difference between the targets
+        and the mean are cached for later use, and the negative
+        marginal log-likelihood is also cached.  This method has no
+        return value, but it does modify the state of the object.
 
-        :param theta: Values of the hyperparameters to use in fitting. Must be a numpy
-                      array with length ``n_params``
+        :param theta: Values of the hyperparameters to use in
+                      fitting. Must be a numpy array with length
+                      ``n_params``
         :type theta: ndarray
         """
 
@@ -367,23 +416,26 @@ class GaussianProcess(object):
 
     @theta.setter
     def theta(self, theta):
-        """
-        Fits the emulator and sets the parameters (property-based setter alias for ``fit``)
+        """Fits the emulator and sets the parameters (property-based setter alias for ``fit``)
 
-        Pre-calculates the matrices needed to compute the log-likelihood and its derivatives
-        and make subsequent predictions. This is called any time the hyperparameter values are
-        changed in order to ensure that all the information is needed to evaluate the
-        log-likelihood and its derivatives, which are needed when fitting the optimal
-        hyperparameters.
+        Pre-calculates the matrices needed to compute the
+        log-likelihood and its derivatives and make subsequent
+        predictions. This is called any time the hyperparameter values
+        are changed in order to ensure that all the information is
+        needed to evaluate the log-likelihood and its derivatives,
+        which are needed when fitting the optimal hyperparameters.
 
-        The method computes the mean function and covariance matrix and inverts the covariance
-        matrix using the method specified by the value of ``nugget``. The factorized matrix
-        and the product of the inverse with the difference between the targets and the mean
-        are cached for later use, and the negative marginal log-likelihood is also cached.
-        This method has no return value, but it does modify the state of the object.
+        The method computes the mean function and covariance matrix
+        and inverts the covariance matrix using the method specified
+        by the value of ``nugget``. The factorized matrix and the
+        product of the inverse with the difference between the targets
+        and the mean are cached for later use, and the negative
+        marginal log-likelihood is also cached.  This method has no
+        return value, but it does modify the state of the object.
 
-        :param theta: Values of the hyperparameters to use in fitting. Must be a numpy
-                      array with length ``n_params``
+        :param theta: Values of the hyperparameters to use in
+                      fitting. Must be a numpy array with length
+                      ``n_params``
         :type theta: ndarray
         :returns: None
         """
@@ -391,32 +443,39 @@ class GaussianProcess(object):
 
     @property
     def priors(self):
-        """
-        The current list priors used in computing the log posterior
+        """The current list priors used in computing the log posterior
 
-        To set the priors, must be a list or ``None``. Entries can be ``None`` or a subclass of ``Prior``.
-        ``None`` indicates weak prior information. An empty list or ``None`` means all uninformative
-        priors. Otherwise list should have the same length as the number of hyperparameters,
-        or alternatively can be one shorter than the number of hyperparameters
-        if ``nugget_type`` is ``"adaptive"`` or ``"fixed"`` meaning that the nugget hyperparameter
-        is not fit but is instead fixed or found adaptively. If the nugget hyperparameter is not fit,
-        the prior for the nugget will automatically be set to ``None`` even if a distribution is
+        To set the priors, must be a list or ``None``. Entries can be
+        ``None`` or a subclass of ``Prior``.  ``None`` indicates weak
+        prior information. An empty list or ``None`` means all
+        uninformative priors. Otherwise list should have the same
+        length as the number of hyperparameters, or alternatively can
+        be one shorter than the number of hyperparameters if
+        ``nugget_type`` is ``"adaptive"``, ``"pivot"`` or ``"fixed"``
+        meaning that the nugget hyperparameter is not fit but is
+        instead fixed or found adaptively. If the nugget
+        hyperparameter is not fit, the prior for the nugget will
+        automatically be set to ``None`` even if a distribution is
         provided.
+
         """
         return self._priors
 
     @priors.setter
     def priors(self, priors):
-        """
-        Sets the priors to a list of prior objects/None
+        """Sets the priors to a list of prior objects/None
 
-        Sets the priors, must be a list or ``None``. Entries can be ``None`` or a subclass of ``Prior``.
-        ``None`` indicates weak prior information. An empty list or ``None`` means all uninformative
-        priors. Otherwise list should have the same length as the number of hyperparameters,
-        or alternatively can be one shorter than the number of hyperparameters
-        if ``nugget_type`` is ``"adaptive"`` or ``"fixed"`` meaning that the nugget hyperparameter
-        is not fit but is instead fixed or found adaptively. If the nugget hyperparameter is not fit,
-        the prior for the nugget will automatically be set to ``None`` even if a distribution is
+        Sets the priors, must be a list or ``None``. Entries can be
+        ``None`` or a subclass of ``Prior``.  ``None`` indicates weak
+        prior information. An empty list or ``None`` means all
+        uninformative priors. Otherwise list should have the same
+        length as the number of hyperparameters, or alternatively can
+        be one shorter than the number of hyperparameters if
+        ``nugget_type`` is ``"adaptive"``,``"pivot"``, or ``"fixed"``
+        meaning that the nugget hyperparameter is not fit but is
+        instead fixed or found adaptively. If the nugget
+        hyperparameter is not fit, the prior for the nugget will
+        automatically be set to ``None`` even if a distribution is
         provided.
         """
 
@@ -448,32 +507,36 @@ class GaussianProcess(object):
 
 
     def get_K_matrix(self):
-        """
-        Returns current value of the covariance matrix as a numpy array. Does not include the nugget
-        parameter, as this is dependent on how the nugget is fit.
+        """Returns current value of the covariance matrix as a numpy
+        array. Does not include the nugget parameter, as this is
+        dependent on how the nugget is fit.
+
         """
         switch = self.mean.get_n_params(self.inputs)
 
         return self.kernel.kernel_f(self.inputs, self.inputs, self.theta[switch:-1])
 
     def fit(self, theta):
-        """
-        Fits the emulator and sets the parameters
+        """Fits the emulator and sets the parameters
 
-        Pre-calculates the matrices needed to compute the log-likelihood and its derivatives
-        and make subsequent predictions. This is called any time the hyperparameter values are
-        changed in order to ensure that all the information is needed to evaluate the
-        log-likelihood and its derivatives, which are needed when fitting the optimal
-        hyperparameters.
+        Pre-calculates the matrices needed to compute the
+        log-likelihood and its derivatives and make subsequent
+        predictions. This is called any time the hyperparameter values
+        are changed in order to ensure that all the information is
+        needed to evaluate the log-likelihood and its derivatives,
+        which are needed when fitting the optimal hyperparameters.
 
-        The method computes the mean function and covariance matrix and inverts the covariance
-        matrix using the method specified by the value of ``nugget_type``. The factorized matrix
-        and the product of the inverse with the difference between the targets and the mean
-        are cached for later use, and the negative marginal log-likelihood is also cached.
-        This method has no return value, but it does modify the state of the object.
+        The method computes the mean function and covariance matrix
+        and inverts the covariance matrix using the method specified
+        by the value of ``nugget_type``. The factorized matrix and the
+        product of the inverse with the difference between the targets
+        and the mean are cached for later use, and the negative
+        marginal log-likelihood is also cached.  This method has no
+        return value, but it does modify the state of the object.
 
-        :param theta: Values of the hyperparameters to use in fitting. Must be a numpy
-                      array with length ``n_params``
+        :param theta: Values of the hyperparameters to use in
+                      fitting. Must be a numpy array with length
+                      ``n_params``
         :type theta: ndarray
         :returns: None
         """
@@ -514,19 +577,21 @@ class GaussianProcess(object):
 
 
     def logposterior(self, theta):
-        """
-        Calculate the negative log-posterior at a particular value of the hyperparameters
+        """Calculate the negative log-posterior at a particular value of the hyperparameters
 
-        Calculate the negative log-posterior for the given set of parameters. Calling this
-        method sets the parameter values and computes the needed inverse matrices in order
-        to evaluate the log-posterior and its derivatives. In addition to returning the
-        log-posterior value, it stores the current value of the hyperparameters and
-        log-posterior in attributes of the object.
+        Calculate the negative log-posterior for the given set of
+        parameters. Calling this method sets the parameter values and
+        computes the needed inverse matrices in order to evaluate the
+        log-posterior and its derivatives. In addition to returning
+        the log-posterior value, it stores the current value of the
+        hyperparameters and log-posterior in attributes of the object.
 
-        :param theta: Value of the hyperparameters. Must be array-like with shape ``(n_params,)``
+        :param theta: Value of the hyperparameters. Must be array-like
+                      with shape ``(n_params,)``
         :type theta: ndarray
         :returns: negative log-posterior
         :rtype: float
+
         """
 
         if self.theta is None or not np.allclose(theta, self.theta, rtol=1.e-10, atol=1.e-15):
@@ -535,26 +600,29 @@ class GaussianProcess(object):
         return self.current_logpost
 
     def logpost_deriv(self, theta):
-        """
-        Calculate the partial derivatives of the negative log-posterior
+        """Calculate the partial derivatives of the negative log-posterior
 
-        Calculate the partial derivatives of the negative log-posterior with respect to
-        the hyperparameters. Note that this function is normally used only when fitting
-        the hyperparameters, and it is not needed to make predictions.
+        Calculate the partial derivatives of the negative
+        log-posterior with respect to the hyperparameters. Note that
+        this function is normally used only when fitting the
+        hyperparameters, and it is not needed to make predictions.
 
-        During normal use, the ``loglike_deriv`` method is called after evaluating the
-        ``logposterior`` method. The implementation takes advantage of this by reusing
-        cached results, as the factorized covariance matrix is expensive to compute and is
-        used by the ``logposterior``, ``logpost_deriv``, and ``logpost_hessian`` methods.
-        If the function is evaluated with a different set of parameters than was previously
-        used to set the log-posterior, the method calls ``fit`` (and subsequently resets
-        the cached information).
+        During normal use, the ``loglike_deriv`` method is called
+        after evaluating the ``logposterior`` method. The
+        implementation takes advantage of this by reusing cached
+        results, as the factorized covariance matrix is expensive to
+        compute and is used by the ``logposterior``,
+        ``logpost_deriv``, and ``logpost_hessian`` methods.  If the
+        function is evaluated with a different set of parameters than
+        was previously used to set the log-posterior, the method calls
+        ``fit`` (and subsequently resets the cached information).
 
-        :param theta: Value of the hyperparameters. Must be array-like with shape
-                      ``(n_params,)``
+        :param theta: Value of the hyperparameters. Must be array-like
+                      with shape ``(n_params,)``
         :type theta: ndarray
-        :returns: partial derivatives of the negative log-posterior with respect to the
-                  hyperparameters (array with shape ``(n_params,)``)
+        :returns: partial derivatives of the negative log-posterior
+                  with respect to the hyperparameters (array with
+                  shape ``(n_params,)``)
         :rtype: ndarray
         """
 
@@ -591,29 +659,33 @@ class GaussianProcess(object):
         return partials
 
     def logpost_hessian(self, theta):
-        """
-        Calculate the Hessian of the negative log-posterior
+        """Calculate the Hessian of the negative log-posterior
 
-        Calculate the Hessian of the negative log-posterior with respect to
-        the hyperparameters. Note that this function is normally used only when fitting
-        the hyperparameters, and it is not needed to make predictions. It is also used
-        to estimate an appropriate step size when fitting hyperparameters using
-        the lognormal approximation or MCMC sampling.
+        Calculate the Hessian of the negative log-posterior with
+        respect to the hyperparameters. Note that this function is
+        normally used only when fitting the hyperparameters, and it is
+        not needed to make predictions. It is also used to estimate an
+        appropriate step size when fitting hyperparameters using the
+        lognormal approximation or MCMC sampling.
 
-        When used in an optimization routine, the ``logpost_hessian`` method is called after
-        evaluating the ``logposterior`` method. The implementation takes advantage of
-        this by storing the inverse of the covariance matrix, which is expensive to
-        compute and is used by the ``logposterior`` and ``logpost_deriv`` methods as well.
-        If the function is evaluated with a different set of parameters than was previously
-        used to set the log-posterior, the method calls ``fit`` to compute the needed
-        information and changes the cached values.
+        When used in an optimization routine, the ``logpost_hessian``
+        method is called after evaluating the ``logposterior``
+        method. The implementation takes advantage of this by storing
+        the inverse of the covariance matrix, which is expensive to
+        compute and is used by the ``logposterior`` and
+        ``logpost_deriv`` methods as well.  If the function is
+        evaluated with a different set of parameters than was
+        previously used to set the log-posterior, the method calls
+        ``fit`` to compute the needed information and changes the
+        cached values.
 
-        :param theta: Value of the hyperparameters. Must be array-like with shape
-                      ``(n_params,)``
+        :param theta: Value of the hyperparameters. Must be array-like
+                      with shape ``(n_params,)``
         :type theta: ndarray
-        :returns: Hessian of the negative log-posterior (array with shape
-                  ``(n_params, n_params)``)
+        :returns: Hessian of the negative log-posterior (array with
+                  shape ``(n_params, n_params)``)
         :rtype: ndarray
+
         """
 
         assert theta.shape == (self.n_params,), "Parameter vector must have length number of inputs + 1"
@@ -678,52 +750,69 @@ class GaussianProcess(object):
         return hessian
 
     def predict(self, testing, unc=True, deriv=True, include_nugget=True):
-        """
-        Make a prediction for a set of input vectors for a single set of hyperparameters
+        """Make a prediction for a set of input vectors for a single set of hyperparameters
 
-        Makes predictions for the emulator on a given set of input vectors. The input vectors
-        must be passed as a ``(n_predict, D)``, ``(n_predict,)`` or ``(D,)`` shaped array-like
-        object, where ``n_predict`` is the number of different prediction points under
-        consideration and ``D`` is the number of inputs to the emulator. If the prediction
-        inputs array is 1D and ``D == 1`` for the GP instance, then the 1D array must have
-        shape ``(n_predict,)``. Otherwise, if the array is 1D it must have shape
-        ``(D,)``, and the method assumes ``n_predict == 1``. The prediction is returned as an
-        ``(n_predict, )`` shaped numpy array as the first return value from the method.
+        Makes predictions for the emulator on a given set of input
+        vectors. The input vectors must be passed as a ``(n_predict,
+        D)``, ``(n_predict,)`` or ``(D,)`` shaped array-like object,
+        where ``n_predict`` is the number of different prediction
+        points under consideration and ``D`` is the number of inputs
+        to the emulator. If the prediction inputs array is 1D and ``D
+        == 1`` for the GP instance, then the 1D array must have shape
+        ``(n_predict,)``. Otherwise, if the array is 1D it must have
+        shape ``(D,)``, and the method assumes ``n_predict == 1``. The
+        prediction is returned as an ``(n_predict, )`` shaped numpy
+        array as the first return value from the method.
 
-        Optionally, the emulator can also calculate the variances in the predictions
-        and the derivatives with respect to each input parameter. If the uncertainties are
-        computed, they are returned as the second output from the method as an ``(n_predict,)``
-        shaped numpy array. If the derivatives are computed, they are returned as the third
-        output from the method as an ``(n_predict, D)`` shaped numpy array.
+        Optionally, the emulator can also calculate the variances in
+        the predictions and the derivatives with respect to each input
+        parameter. If the uncertainties are computed, they are
+        returned as the second output from the method as an
+        ``(n_predict,)`` shaped numpy array. If the derivatives are
+        computed, they are returned as the third output from the
+        method as an ``(n_predict, D)`` shaped numpy array.
 
-        The final input to the method determines if the predictive variance should include
-        the nugget or not. For situations where the nugget represents observational error
-        and predictions are estimating the true underlying function, this should be set to
-        ``False``. However, most other cases should probably include the nugget, as the
-        emulator is using it to represent some of the uncertainty in the underlying simulator,
+        The final input to the method determines if the predictive
+        variance should include the nugget or not. For situations
+        where the nugget represents observational error and
+        predictions are estimating the true underlying function, this
+        should be set to ``False``. However, most other cases should
+        probably include the nugget, as the emulator is using it to
+        represent some of the uncertainty in the underlying simulator,
         so the default value is ``True``.
 
-        :param testing: Array-like object holding the points where predictions will be made.
-                        Must have shape ``(n_predict, D)`` or ``(D,)`` (for a single prediction)
+        :param testing: Array-like object holding the points where
+                        predictions will be made.  Must have shape
+                        ``(n_predict, D)`` or ``(D,)`` (for a single
+                        prediction)
         :type testing: ndarray
-        :param unc: (optional) Flag indicating if the uncertainties are to be computed.
-                    If ``False`` the method returns ``None`` in place of the uncertainty
+
+        :param unc: (optional) Flag indicating if the uncertainties
+                    are to be computed.  If ``False`` the method
+                    returns ``None`` in place of the uncertainty
                     array. Default value is ``True``.
         :type unc: bool
-        :param deriv: (optional) Flag indicating if the derivatives are to be computed.
-                      If ``False`` the method returns ``None`` in place of the derivative
+        :param deriv: (optional) Flag indicating if the derivatives
+                      are to be computed.  If ``False`` the method
+                      returns ``None`` in place of the derivative
                       array. Default value is ``True``.
         :type deriv: bool
-        :param include_nugget: (optional) Flag indicating if the nugget should be included
-                               in the predictive variance. Only relevant if ``unc = True``.
-                               Default is ``True``.
+
+        :param include_nugget: (optional) Flag indicating if the
+                               nugget should be included in the
+                               predictive variance. Only relevant if
+                               ``unc = True``.  Default is ``True``.
         :type include_nugget: bool
-        :returns: Tuple of numpy arrays holding the predictions, uncertainties, and derivatives,
-                  respectively. Predictions and uncertainties have shape ``(n_predict,)``
-                  while the derivatives have shape ``(n_predict, D)``. If the ``unc`` or
-                  ``deriv`` flags are set to ``False``, then those arrays are replaced by
-                  ``None``.
+
+        :returns: Tuple of numpy arrays holding the predictions,
+                  uncertainties, and derivatives,
+                  respectively. Predictions and uncertainties have
+                  shape ``(n_predict,)`` while the derivatives have
+                  shape ``(n_predict, D)``. If the ``unc`` or
+                  ``deriv`` flags are set to ``False``, then those
+                  arrays are replaced by ``None``.
         :rtype: tuple
+
         """
 
         if self.theta is None:
@@ -769,42 +858,51 @@ class GaussianProcess(object):
         calling `predict` without uncertainty and derivative
         predictions, and extracting the zeroth component for the
         'mean' prediction.
+
         """
         return (self.predict(testing, unc=False, deriv=False)[0])
 
     def __str__(self):
-        """
-        Returns a string representation of the model
+        """Returns a string representation of the model
 
-        :returns: A string representation of the model (indicates number of training examples
-                  and inputs)
+        :returns: A string representation of the model (indicates
+                  number of training examples and inputs)
         :rtype: str
+
         """
 
         return ("Gaussian Process with " + str(self.n) + " training examples and " +
                 str(self.D) + " input variables")
 
 class PredictResult(dict):
-    """
-    Prediction results object
+    """Prediction results object
 
-    Dictionary-like object containing mean, uncertainty (variance), and derivatives with
-    respect to the inputs of an emulator prediction. Values can be accessed like a dictionary
-    with keys ``'mean'``, ``'unc'``, and ``'deriv'`` (or indices 0, 1, and 2 for the mean,
-    uncertainty, and derivative for backwards compatability), or using attributes
-    (``p.mean`` if ``p`` is an instance of ``PredictResult``). Also supports iteration and
-    unpacking with the ordering ``(mean, unc, deriv)`` to be consistent with indexing behavior.
+    Dictionary-like object containing mean, uncertainty (variance),
+    and derivatives with respect to the inputs of an emulator
+    prediction. Values can be accessed like a dictionary with keys
+    ``'mean'``, ``'unc'``, and ``'deriv'`` (or indices 0, 1, and 2 for
+    the mean, uncertainty, and derivative for backwards
+    compatability), or using attributes (``p.mean`` if ``p`` is an
+    instance of ``PredictResult``). Also supports iteration and
+    unpacking with the ordering ``(mean, unc, deriv)`` to be
+    consistent with indexing behavior.
 
-    Code is mostly based on scipy's ``OptimizeResult`` class, with some additional code to
-    support iteration and integer indexing.
+    Code is mostly based on scipy's ``OptimizeResult`` class, with
+    some additional code to support iteration and integer indexing.
 
-    :ivar mean: Predicted mean for each input point. Numpy array with shape ``(n_predict,)``
+    :ivar mean: Predicted mean for each input point. Numpy array with
+                shape ``(n_predict,)``
     :type mean: ndarray
-    :ivar unc: Predicted variance for each input point. Numpy array with shape ``(n_predict,)``
+
+    :ivar unc: Predicted variance for each input point. Numpy array
+               with shape ``(n_predict,)``
     :type mean: ndarray
-    :ivar deriv: Predicted derivative with respect to the inputs for each input point.
-                 Numpy array with shape ``(n_predict, D)``
+
+    :ivar deriv: Predicted derivative with respect to the inputs for
+                 each input point.  Numpy array with shape
+                 ``(n_predict, D)``
     :type deriv: ndarray
+
     """
 
     def __getattr__(self, name):

--- a/mogp_emulator/GaussianProcess.py
+++ b/mogp_emulator/GaussianProcess.py
@@ -4,7 +4,7 @@ from mogp_emulator.Kernel import Kernel, SquaredExponential, Matern52
 from mogp_emulator.Priors import Prior
 from scipy import linalg
 from scipy.optimize import OptimizeResult
-from mogp_emulator.linalg.cholesky import jit_cholesky, pivot_cholesky, pivot_transpose
+from mogp_emulator.linalg import jit_cholesky, pivot_cholesky, pivot_transpose
 
 class GaussianProcess(object):
     """

--- a/mogp_emulator/GaussianProcess.py
+++ b/mogp_emulator/GaussianProcess.py
@@ -662,7 +662,7 @@ class GaussianProcess(object):
                                                                                        linalg.cho_solve((self.L, True),
                                                                                                         np.eye(self.n)[self.P])[pivot_transpose(self.P)])[self.P])[pivot_transpose(self.P)]))
 
-            hessian[-1, -1] = 0.5*nugget*(np.trace(linalg.cho_solve((self.L, True), np.eye(self.n)[self.P])[pivot_tranpose(self.P)]) -
+            hessian[-1, -1] = 0.5*nugget*(np.trace(linalg.cho_solve((self.L, True), np.eye(self.n)[self.P])[pivot_transpose(self.P)]) -
                                                    np.dot(self.invQt, self.invQt))
             hessian[-1, -1] += nugget**2*(np.dot(self.invQt, invQinvQt) -
                                           0.5*np.trace(linalg.cho_solve((self.L, True),

--- a/mogp_emulator/benchmarks/Makefile
+++ b/mogp_emulator/benchmarks/Makefile
@@ -7,14 +7,15 @@
 help : Makefile
 	@sed -n 's/^##//p' $<
 
-## all        : Run unit tests and benchmarks
+## all        : Run all benchmarks
 .PHONY: all
 all: benchmarks
 
 ## benchmarks : Run the Branin, Rosenbrock (convergence), Tsunami (performance),
-##            : MICE, and History Matching benchmarks
+##            : Pivoted Cholesky, MICE, dimension reduction,
+##            : and History Matching benchmarks
 .PHONY: benchmarks
-benchmarks: branin tsunami rosenbrock mice mcmc gKDR histmatch
+benchmarks: branin tsunami rosenbrock pivot mice gKDR histmatch
 
 ## branin     : Run the 2D Branin tests of convergence. Produces the plots
 ##            : branin_2d_error.png and branin_2d_unc.png
@@ -41,15 +42,15 @@ mice: mice_error.png mice_unc.png
 .PHONY: histmatch
 histmatch: histmatch_1D.png histmatch_2D.png
 
-## mcmc       : Run the MCMC sampling benchmark
-##            : Produces the plot MCMC_histogram.png
-.PHONY: mcmc
-mcmc: MCMC_histogram.png
-
 ## gKDR       : Run the dimension reduction benchmark
 ##            : Produces the plot benchmark_kdr_GP_loss.pdf
 .PHONY: gKDR
 gKDR: benchmark_kdr_GP_loss.pdf
+
+## pivot      : Run the pivoted Cholesky decomposition benchmark
+##            : Produces the plots pivot_error.png and pivot_unc.png
+.PHONY: pivot
+pivot: pivot_error.png pivot_unc.png
 
 # commands above are shortcuts to the targets below
 
@@ -71,5 +72,6 @@ histmatch_1D.png histmatch_2D.png: benchmark_historymatching.py
 benchmark_kdr_GP_loss.pdf benchmark_kdr_GP_loss.npy: benchmark_kdr_GP.py
 	python3 benchmark_kdr_GP.py
 
-MCMC_histogram.png: benchmark_MCMC.py
-	python3 benchmark_MCMC.py
+pivot_error.png pivot_unc.png: benchmark_pivot.py
+	python3 benchmark_pivot.py
+

--- a/mogp_emulator/benchmarks/benchmark_pivot.py
+++ b/mogp_emulator/benchmarks/benchmark_pivot.py
@@ -1,20 +1,26 @@
-'''
-This benchmark performs convergence tests using the pivoted Cholesky routines applied to the
-2D Branin function. Details of the 2D Branin function can be found at
-https://www.sfu.ca/~ssurjano/branin.html. The code samples the Branin function using an increasing
-number of points, with a duplicate point added to make the matrix singular. When pivoting is not
-used, the algorithm is stabilized by adding a nugget term to the diagonal of the covariance matrix.
-This degrades the performance of the emulator globally, despite the fact that the problem arises
-from a local problem in fitting the emulator. Pivoting ignores points that are too close to one
-another, ensuring that there is no loss of performance as the number of points increases.
+'''This benchmark performs convergence tests using the pivoted
+Cholesky routines applied to the 2D Branin function. Details of the 2D
+Branin function can be found at
+https://www.sfu.ca/~ssurjano/branin.html. The code samples the Branin
+function using an increasing number of points, with a duplicate point
+added to make the matrix singular. When pivoting is not used, the
+algorithm is stabilized by adding a nugget term to the diagonal of the
+covariance matrix.  This degrades the performance of the emulator
+globally, despite the fact that the problem arises from a local
+problem in fitting the emulator. Pivoting ignores points that are too
+close to one another, ensuring that there is no loss of performance as
+the number of points increases.
 
-Note that this benchmark only covers relatively small designs. Tests have revealed that there are
-some stability issues when applying pivoting to larger numbers of inputs -- this appears to be
-due to the minimization algorithm, perhaps due to the fact that pivoting computes the inverse of
-a slightly different matrix which may make the gradient computations incorrect. Care should
-thus be taken to examine the resulting performance when applying pivoting in practice. Future
-versions may implement other approaches to ensure that pivoting gives stable performance
-on a wide variety of input data.
+Note that this benchmark only covers relatively small designs. Tests
+have revealed that there are some stability issues when applying
+pivoting to larger numbers of inputs -- this appears to be due to the
+minimization algorithm, perhaps due to the fact that pivoting computes
+the inverse of a slightly different matrix which may influence the
+fitting algorithm performance. Care should thus be taken to examine
+the resulting performance when applying pivoting in practice. Future
+versions may implement other approaches to ensure that pivoting gives
+stable performance on a wide variety of input data.
+
 '''
 
 import numpy as np

--- a/mogp_emulator/benchmarks/benchmark_pivot.py
+++ b/mogp_emulator/benchmarks/benchmark_pivot.py
@@ -1,0 +1,188 @@
+'''
+This benchmark performs convergence tests using the pivoted Cholesky routines applied to the
+2D Branin function. Details of the 2D Branin function can be found at
+https://www.sfu.ca/~ssurjano/branin.html. The code samples the Branin function using an increasing
+number of points, with a duplicate point added to make the matrix singular. When pivoting is not
+used, the algorithm is stabilized by adding a nugget term to the diagonal of the covariance matrix.
+This degrades the performance of the emulator globally, despite the fact that the problem arises
+from a local problem in fitting the emulator. Pivoting ignores points that are too close to one
+another, ensuring that there is no loss of performance as the number of points increases.
+
+Note that this benchmark only covers relatively small designs. Tests have revealed that there are
+some stability issues when applying pivoting to larger numbers of inputs -- this appears to be
+due to the minimization algorithm, perhaps due to the fact that pivoting computes the inverse of
+a slightly different matrix which may make the gradient computations incorrect. Care should
+thus be taken to examine the resulting performance when applying pivoting in practice. Future
+versions may implement other approaches to ensure that pivoting gives stable performance
+on a wide variety of input data.
+'''
+
+import numpy as np
+from mogp_emulator import GaussianProcess, fit_GP_MAP
+from mogp_emulator import MonteCarloDesign, LatinHypercubeDesign
+from scipy.stats import uniform
+try:
+    import matplotlib.pyplot as plt
+    makeplots = True
+except ImportError:
+    makeplots = False
+
+def branin_2d(x):
+    "2D Branin function, see https://www.sfu.ca/~ssurjano/branin.html for more information"
+    if np.array(x).shape == (2,):
+        x1, x2 = x
+    else:
+        assert len(np.array(x).shape) == 2
+        assert np.array(x).shape[1] == 2
+        x1 = x[:,0]
+        x2 = x[:,1]
+    a, b, c, r, s, t = 1., 5.1/4./np.pi**2, 5./np.pi, 6., 10., 1./8./np.pi
+    return a*(x2 - b*x1**2 + c*x1 - r)**2 + s*(1. - t)*np.cos(x1) + s
+
+
+f = branin_2d
+n_dim = 2
+design_space = [uniform(loc = -5., scale = 15.).ppf, uniform(loc = 0., scale = 15.).ppf]
+simulations = [5, 10, 15, 20, 25, 30]
+
+def generate_input_data(n_simulations, method = "random"):
+    "Generate random points x1 and x2 for evaluating the multivalued 2D Branin function"
+    
+    n_simulations = int(n_simulations)
+    assert(n_simulations > 0)
+    assert method == "random" or method == "lhd"
+    
+    if method == "random":
+        ed = MonteCarloDesign(design_space)
+    elif method == "lhd":
+        ed = LatinHypercubeDesign(design_space)
+    inputs = ed.sample(n_simulations)
+    return inputs
+    
+def generate_target_data(inputs):
+    "Generate target data for multivalued emulator benchmark"
+    
+    inputs = np.array(inputs)
+    assert len(inputs.shape) == 2
+    assert inputs.shape[1] == n_dim
+    n_simulations = inputs.shape[0]
+    
+    targets = f(inputs)
+        
+    return targets
+
+def generate_training_data(n_simulations):
+    "Generate n_simulations input data and add a duplicate point to make matrix singular"
+    
+    inputs = generate_input_data(n_simulations, method = "lhd")
+    targets = generate_target_data(inputs)
+    
+    inputs_new = np.zeros((inputs.shape[0] + 1, inputs.shape[1]))
+    targets_new = np.zeros(targets.shape[0] + 1)
+    
+    inputs_new[:-1, :] = np.copy(inputs)
+    targets_new[:-1] = np.copy(targets)
+    
+    inputs_new[-1,:] = np.copy(inputs[0,:])
+    targets_new[-1] = np.copy(targets[0])
+    
+    return inputs_new, targets_new
+    
+def generate_test_data(n_testing):
+    "Generate n_testing points for testing the accuracy of an emulator"
+    
+    testing = generate_input_data(n_testing, method = "random")
+    test_targets = generate_target_data(testing)
+    
+    return testing, test_targets
+    
+def run_model(n_simulations, n_testing):
+    "Generate training data, fit emulator, and test model accuracy on random points, returning RMSE"
+    
+    print('fitting GPs')
+    
+    # run LHD model
+    inputs, targets = generate_training_data(n_simulations)
+    
+    gp = GaussianProcess(inputs, targets, nugget="adaptive")
+    gp = fit_GP_MAP(gp)
+    
+    print("fitting pivoted GP")
+    
+    gp_pivot = GaussianProcess(inputs, targets, nugget="pivot")
+    gp_pivot = fit_GP_MAP(gp_pivot)
+    
+    print("making predictions")
+
+    testing, test_targets = generate_test_data(n_testing)
+    
+    norm_const = np.max(test_targets)-np.min(test_targets)
+    
+    test_vals_pivot, unc_pivot, deriv = gp_pivot.predict(testing, deriv = False, unc = True)
+    test_vals, unc, deriv = gp.predict(testing, deriv = False, unc = True)
+    
+    return (np.sqrt(np.sum((test_vals - test_targets)**2)/float(n_testing))/norm_const,
+            np.sqrt(np.sum(unc**2)/float(n_testing))/norm_const**2,
+            np.sqrt(np.sum((test_vals_pivot - test_targets)**2)/float(n_testing))/norm_const,
+            np.sqrt(np.sum(unc_pivot**2)/float(n_testing))/norm_const**2)
+
+def plot_model_errors(simulation_list, error, unc, error_pivot, unc_pivot, n_testing):
+    "Makes plot showing accuracy of emulator as a function of n_simulations"
+    
+    plt.figure(figsize=(4,3))
+    plt.semilogy(simulation_list, error_pivot,'-o', label = 'Pivot')
+    plt.semilogy(simulation_list, error,'-x', label = 'Nugget')
+    plt.xlabel('Number of design points')
+    plt.ylabel('Average prediction RMSE')
+    plt.legend()
+    plt.title('Error for '+str(n_testing)+' predictions')
+    plt.savefig('pivot_error.png',bbox_inches='tight')
+    
+    plt.figure(figsize=(4,3))
+    plt.semilogy(simulation_list, unc_pivot,'-o', label = "Pivot")
+    plt.semilogy(simulation_list, unc,'-x', label = 'Nugget')
+    plt.xlabel('Number of design points')
+    plt.ylabel('Average prediction variance')
+    plt.legend()
+    plt.title('Uncertainty for '+str(n_testing)+' predictions')
+    plt.savefig('pivot_unc.png',bbox_inches='tight')
+    
+def run_all_models(n_testing, simulation_list, n_iter = 10):
+    "Runs all models, printing out results and optionally making plots"
+    
+    n_simtrials = len(simulation_list)
+    
+    errors = np.zeros((n_simtrials, n_iter))
+    uncs = np.zeros((n_simtrials, n_iter))
+    errors_pivot = np.zeros((n_simtrials, n_iter))
+    uncs_pivot = np.zeros((n_simtrials, n_iter))
+    
+    for iteration in range(n_iter):
+        for sim_index in range(n_simtrials):
+            print(sim_index, iteration)
+            (errors[sim_index, iteration],
+             uncs[sim_index, iteration],
+             errors_pivot[sim_index, iteration],
+             uncs_pivot[sim_index, iteration]) = run_model(simulation_list[sim_index], n_testing)
+    
+    error = np.mean(errors, axis = -1)
+    unc = np.mean(uncs, axis = -1)
+    error_pivot = np.mean(errors_pivot, axis = -1)
+    unc_pivot = np.mean(uncs_pivot, axis = -1)
+    
+    print("\n")
+    print("Convergence test results:")
+    print("Num. design points  RMSE Nugget         RMSE Pivot")
+    for sim, err, pivot_err in zip(simulation_list, error, error_pivot):
+        print('{:19} {:19} {:19}'.format(str(sim), str(err), str(pivot_err)))
+        
+    print("\n")
+    print("Num. design points  Variance Nugget     Variance Pivot")
+    for sim, un, pivot_un in zip(simulation_list, unc, unc_pivot):
+        print('{:19} {:19} {:19}'.format(str(sim), str(un), str(pivot_un)))
+    
+    if makeplots:
+        plot_model_errors(simulation_list, error, unc, error_pivot, unc_pivot, n_testing)
+    
+if __name__ == '__main__':
+    run_all_models(100, [int(x) for x in simulations], n_iter = 10)

--- a/mogp_emulator/linalg/__init__.py
+++ b/mogp_emulator/linalg/__init__.py
@@ -1,1 +1,1 @@
-from mogp_emulator.linalg.cholesky import jit_cholesky, pivot_cholesky, pivot_transpose
+from mogp_emulator.linalg.cholesky import jit_cholesky, pivot_cholesky, pivot_cho_solve

--- a/mogp_emulator/linalg/__init__.py
+++ b/mogp_emulator/linalg/__init__.py
@@ -1,0 +1,1 @@
+from mogp_emulator.linalg.cholesky import jit_cholesky, pivot_cholesky, pivot_transpose

--- a/mogp_emulator/linalg/cholesky.py
+++ b/mogp_emulator/linalg/cholesky.py
@@ -124,9 +124,28 @@ def pivot_cholesky(A):
     return L, P-1
     
 def pivot_transpose(P):
-    "invert a pivot matrix"
+    """
+    Invert a pivot matrix by taking its transpose
+
+    Inverts the pivot matrix by taking its transpose. Since the pivot
+    matrix is represented by an array of integers(to make swapping the
+    rows more simple by using numpy indexing), this is done by
+    creating the equivalent array of integers representing the
+    transpose.  Input must be a list of non-negative integers, where
+    each integer up to the length of the array appears exactly
+    once. Otherwise this function will raise an exception.
+
+    :param P: Input pivot matrix, represented as an array of non-negative
+              integers.
+    :type P: ndarray containing integers
+    :returns: Transpose of the pivot matrix, represented as an array of
+              non-negative integers.
+    :rtype: ndarray containing integers.
+    """
 
     assert np.array(P).ndim == 1, "pivot matrix must be a list of integers"
-    assert all([idx in P for idx in range(len(P))]), "pivot matrix must contain all integers up to its length exactly once"
 
-    return np.array([np.where(P == idx)[0][0] for idx in range(len(P))], dtype=np.int32)
+    try:
+        return np.array([np.where(P == idx)[0][0] for idx in range(len(P))], dtype=np.int32)
+    except IndexError:
+        raise ValueError("Bad values for pivot matrix input to pivot_transpose")

--- a/mogp_emulator/linalg/cholesky.py
+++ b/mogp_emulator/linalg/cholesky.py
@@ -110,8 +110,10 @@ def pivot_cholesky(A):
 
     A = np.ascontiguousarray(A)
     L, P, rank, info = lapack.dpstrf(A, lower = 1)
-
-    # if info is unacceptable, raise an error
+    L = np.tril(L)
+    
+    if info < 0:
+        raise linalg.LinAlgError("Illegal value in covariance matrix")
     
     n = A.shape[0]
 
@@ -123,5 +125,8 @@ def pivot_cholesky(A):
     
 def pivot_transpose(P):
     "invert a pivot matrix"
+
+    assert np.array(P).ndim == 1, "pivot matrix must be a list of integers"
+    assert all([idx in P for idx in range(len(P))]), "pivot matrix must contain all integers up to its length exactly once"
 
     return np.array([np.where(P == idx)[0][0] for idx in range(len(P))], dtype=np.int32)

--- a/mogp_emulator/linalg/cholesky.py
+++ b/mogp_emulator/linalg/cholesky.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import linalg
 from scipy.linalg import lapack
 
-def check_cholesky_inputs(A):
+def _check_cholesky_inputs(A):
     """
     Check inputs to cholesky routines
 
@@ -56,7 +56,7 @@ def jit_cholesky(A, maxtries = 5):
     :rtype: tuple containing an ndarray and a float
     """
 
-    A = check_cholesky_inputs(A)
+    A = _check_cholesky_inputs(A)
     assert int(maxtries) > 0, "maxtries must be a positive integer"
 
     A = np.ascontiguousarray(A)
@@ -97,7 +97,8 @@ def pivot_cholesky(A):
     indices indicating the pivoting order. Raises an error if the
     decomposition fails.
 
-    :param A: The matrix to be inverted as an array of shape ``(n,n)``. Must be a symmetric matrix (though can be singular).
+    :param A: The matrix to be inverted as an array of shape ``(n,n)``.
+              Must be a symmetric matrix (though can be singular).
     :type A: ndarray
     :returns: Lower-triangular factored matrix (shape ``(n,n)`` an an array of
               integers indicating the pivoting order needed to produce the
@@ -106,7 +107,7 @@ def pivot_cholesky(A):
             ndarray of shape `(n,)` of integers. 
     """
 
-    A = check_cholesky_inputs(A)
+    A = _check_cholesky_inputs(A)
 
     A = np.ascontiguousarray(A)
     L, P, rank, info = lapack.dpstrf(A, lower = 1)
@@ -141,6 +142,7 @@ def pivot_transpose(P):
     :returns: Transpose of the pivot matrix, represented as an array of
               non-negative integers.
     :rtype: ndarray containing integers.
+
     """
 
     assert np.array(P).ndim == 1, "pivot matrix must be a list of integers"

--- a/mogp_emulator/tests/test_GaussianProcess.py
+++ b/mogp_emulator/tests/test_GaussianProcess.py
@@ -100,6 +100,10 @@ def test_GaussianProcess_nugget(x, y):
     assert_allclose(gp.nugget, 0.)
     assert gp.nugget_type == "fixed"
 
+    gp.nugget = "pivot"
+    assert gp.nugget is None
+    assert gp.nugget_type == "pivot"
+    
     with pytest.raises(TypeError):
         gp.nugget = [1]
 
@@ -111,6 +115,7 @@ def test_GaussianProcess_nugget(x, y):
 
 
 @pytest.mark.parametrize("mean,nugget,sn", [(None, 0., 1.), (None, "adaptive", 0.),
+                                            (None, "pivot", 0.),
                                             (MeanFunction("x[0]"), "fit", np.log(1.e-6))])
 def test_GaussianProcess_theta(x, y, mean, nugget, sn):
     "test the theta property of GaussianProcess (effectively the same as fit)"
@@ -126,7 +131,7 @@ def test_GaussianProcess_theta(x, y, mean, nugget, sn):
 
     switch = gp.mean.get_n_params(x)
 
-    if nugget == "adaptive" or nugget == 0.:
+    if nugget == "adaptive" or nugget == 0. or nugget == "pivot":
         assert gp.nugget == 0.
         noise = 0.
     else:
@@ -145,6 +150,26 @@ def test_GaussianProcess_theta(x, y, mean, nugget, sn):
     assert_allclose(invQt_expect, gp.invQt)
     assert_allclose(logpost_expect, gp.current_logpost)
 
+def test_GaussianProcess_theta_pivot():
+    "test that pivoting works as expected"
+
+    # input arrays are re-ordered such that pivoting should re-order the second to match the first
+
+    x1 = np.array([1., 4., 2.])
+    x2 = np.array([1., 2., 4.])
+    y1 = np.array([1., 1., 2.])
+    y2 = np.array([1., 2., 1.])
+
+    gp1 = GaussianProcess(x1, y1, nugget=0.)
+    gp2 = GaussianProcess(x2, y2, nugget="pivot")
+
+    gp1.theta = np.zeros(3)
+    gp2.theta = np.zeros(3)
+
+    assert_allclose(gp1.L, gp2.L)
+    assert_allclose(gp1.invQt, gp2.invQt[gp2.P])
+    assert np.array_equal(gp2.P, [0, 2, 1])
+    
 def test_GaussianProcess_priors(x, y):
     "test that priors are set properly"
 
@@ -192,6 +217,7 @@ def test_GaussianProcess_priors(x, y):
         GaussianProcess(x, y, priors=priors)
 
 @pytest.mark.parametrize("mean,nugget,sn", [(None, 0., 1.), (None, "adaptive", 0.),
+                                            (None, "pivot", 0.),
                                             (MeanFunction("x[0]"), "fit", np.log(1.e-6))])
 def test_GaussianProcess_fit_logposterior(x, y, mean, nugget, sn):
     "test the fit and logposterior methods of GaussianProcess"
@@ -207,7 +233,7 @@ def test_GaussianProcess_fit_logposterior(x, y, mean, nugget, sn):
 
     switch = gp.mean.get_n_params(x)
 
-    if nugget == "adaptive" or nugget == 0.:
+    if nugget == "adaptive" or nugget == 0. or nugget == "pivot":
         assert gp.nugget == 0.
         noise = 0.
     else:
@@ -257,6 +283,7 @@ def dx():
     return 1.e-6
 
 @pytest.mark.parametrize("mean,nugget,sn", [(None, 0., 1.), (None, "adaptive", 1.),
+                                            (None, "pivot", 1.),
                                             ("x[0]", "fit", np.log(1.e-6))])
 def test_GaussianProcess_logpost_deriv(x, y, dx, mean, nugget, sn):
     "test logposterior derivatives for GaussianProcess via finite differences"
@@ -276,7 +303,8 @@ def test_GaussianProcess_logpost_deriv(x, y, dx, mean, nugget, sn):
 
     assert_allclose(deriv, gp.logpost_deriv(theta), atol=1.e-7, rtol=1.e-5)
 
-@pytest.mark.parametrize("mean,nugget,sn", [(None, 0., 1.), ("x[0]", "fit", np.log(1.e-6))])
+@pytest.mark.parametrize("mean,nugget,sn", [(None, 0., 1.),
+                                            (None, "pivot", 1.), ("x[0]", "fit", np.log(1.e-6))])
 def test_GaussianProcess_logpost_hessian(x, y, dx, mean, nugget, sn):
     "test the hessian method of GaussianProcess with finite differences"
 
@@ -494,6 +522,31 @@ def test_GaussianProcess_predict_nugget(x, y):
 
     assert_allclose(preds.unc, var_expect, atol=1.e-7)
 
+def test_GaussianProcess_predict_pivot():
+    "test that pivoting gives same predictions as standard version"
+
+    # input arrays are re-ordered such that pivoting should re-order the second to match the first
+    
+    x1 = np.array([1., 4., 2.])
+    x2 = np.array([1., 2., 4.])
+    y1 = np.array([1., 1., 2.])
+    y2 = np.array([1., 2., 1.])
+
+    gp1 = GaussianProcess(x1, y1, nugget=0.)
+    gp2 = GaussianProcess(x2, y2, nugget="pivot")
+
+    gp1.theta = np.zeros(3)
+    gp2.theta = np.zeros(3)
+
+    xpred = np.linspace(0., 5.)
+
+    mean1, var1, deriv1 = gp1.predict(xpred)
+    mean2, var2, deriv2 = gp2.predict(xpred)
+
+    assert_allclose(mean1, mean2)
+    assert_allclose(var1, var2)
+    assert_allclose(deriv1, deriv2)
+    
 def test_GaussianProcess_predict_variance():
     "confirm that caching factorized matrix produces stable variance predictions"
 

--- a/mogp_emulator/tests/test_linalg.py
+++ b/mogp_emulator/tests/test_linalg.py
@@ -91,5 +91,10 @@ def test_pivot_transpose():
     
     P = np.array([1, 2, 1], dtype = np.int32)
     
+    with pytest.raises(ValueError):
+        pivot_transpose(P)
+
+    P = np.array([[0, 1, 2], [2, 1, 0]], dtype=np.int32)
+
     with pytest.raises(AssertionError):
         pivot_transpose(P)

--- a/mogp_emulator/tests/test_linalg.py
+++ b/mogp_emulator/tests/test_linalg.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from ..linalg.cholesky import jit_cholesky, check_cholesky_inputs, pivot_cholesky, pivot_transpose
+from scipy import linalg
+
+def test_check_cholesky_inputs():
+    "Test function that checks inputs to cholesky decomposition routines"
+    
+    A = np.array([[2., 1.], [1., 2.]])
+    B = check_cholesky_inputs(A)
+    
+    assert_allclose(A, B)
+
+    A = np.array([[1., 2.], [1., 2.]])
+    with pytest.raises(AssertionError):
+        check_cholesky_inputs(A)
+    
+    A = np.array([1., 2.])
+    with pytest.raises(AssertionError):
+        check_cholesky_inputs(A)
+        
+    A = np.array([[1., 2., 3.], [4., 5., 6.]])
+    with pytest.raises(AssertionError):
+        check_cholesky_inputs(A)
+    
+    input_matrix = np.array([[-1., 2., 2.], [2., 3., 2.], [2., 2., -3.]])
+    with pytest.raises(linalg.LinAlgError):
+        check_cholesky_inputs(input_matrix)
+
+def test_jit_cholesky():
+    "Tests the stabilized Cholesky decomposition routine"
+    
+    L_expected = np.array([[2., 0., 0.], [6., 1., 0.], [-8., 5., 3.]])
+    input_matrix = np.array([[4., 12., -16.], [12., 37., -43.], [-16., -43., 98.]])
+    L_actual, jitter = jit_cholesky(input_matrix)
+    assert_allclose(L_expected, L_actual)
+    assert_allclose(jitter, 0.)
+    
+    L_expected = np.array([[1.0000004999998751e+00, 0.0000000000000000e+00, 0.0000000000000000e+00],
+                         [9.9999950000037496e-01, 1.4142132088085626e-03, 0.0000000000000000e+00],
+                         [6.7379436301144941e-03, 4.7644444411381860e-06, 9.9997779980004420e-01]])
+    input_matrix = np.array([[1.                , 1.                , 0.0067379469990855],
+                             [1.                , 1.                , 0.0067379469990855],
+                             [0.0067379469990855, 0.0067379469990855, 1.                ]])
+    L_actual, jitter = jit_cholesky(input_matrix)
+    assert_allclose(L_expected, L_actual)
+    assert_allclose(jitter, 1.e-6)
+    
+    input_matrix = np.array([[1.e-6, 1., 0.], [1., 1., 1.], [0., 1., 1.e-10]])
+    with pytest.raises(linalg.LinAlgError):
+        jit_cholesky(input_matrix)
+
+def test_pivot_cholesky():
+    "Tests  pivoted cholesky decomposition routine"
+    
+    input_matrix = np.array([[4., 12., -16.], [12., 37., -43.], [-16., -43., 98.]])
+    input_matrix_copy = np.copy(input_matrix)
+    L_expected = np.array([[ 9.899494936611665 ,  0.                ,  0.                ],
+                           [-4.3436559415745055,  4.258245303082538 ,  0.                ],
+                           [-1.616244071283537 ,  1.1693999481734827,  0.1423336335961131]])
+    Piv_expected = np.array([2, 1, 0], dtype = np.int32)
+    
+    L_actual, Piv_actual = pivot_cholesky(input_matrix)
+    
+    assert_allclose(L_actual, L_expected)
+    assert np.array_equal(Piv_expected, Piv_actual)
+    assert_allclose(input_matrix, input_matrix_copy)
+    
+    input_matrix = np.array([[1., 1., 1.e-6], [1., 1., 1.e-6], [1.e-6, 1.e-6, 1.]])
+    input_matrix_copy = np.copy(input_matrix)
+    L_expected = np.array([[1.0000000000000000e+00, 0.0000000000000000e+00, 0.0000000000000000e+00],
+                           [9.9999999999999995e-07, 9.9999999999949996e-01, 0.0000000000000000e+00],
+                           [1.0000000000000000e+00, 0.0000000000000000e+00, 3.3333333333316667e-01]])
+    Piv_expected = np.array([0, 2, 1], dtype=np.int32)               
+    
+    L_actual, Piv_actual = pivot_cholesky(input_matrix)
+    
+    assert_allclose(L_actual, L_expected)
+    assert np.array_equal(Piv_expected, Piv_actual)
+    assert_allclose(input_matrix, input_matrix_copy)
+    
+def test_pivot_transpose():
+    "Test function to invert pivot matrix"
+    
+    P = np.array([0, 2, 1], dtype = np.int32)
+    
+    Piv = pivot_transpose(P)
+    
+    np.array_equal(Piv, P)
+    
+    P = np.array([1, 2, 1], dtype = np.int32)
+    
+    with pytest.raises(AssertionError):
+        pivot_transpose(P)

--- a/mogp_emulator/tests/test_linalg.py
+++ b/mogp_emulator/tests/test_linalg.py
@@ -1,32 +1,32 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from ..linalg.cholesky import jit_cholesky, check_cholesky_inputs, pivot_cholesky, pivot_transpose
+from ..linalg.cholesky import jit_cholesky, _check_cholesky_inputs, pivot_cholesky, pivot_transpose
 from scipy import linalg
 
 def test_check_cholesky_inputs():
     "Test function that checks inputs to cholesky decomposition routines"
     
     A = np.array([[2., 1.], [1., 2.]])
-    B = check_cholesky_inputs(A)
+    B = _check_cholesky_inputs(A)
     
     assert_allclose(A, B)
 
     A = np.array([[1., 2.], [1., 2.]])
     with pytest.raises(AssertionError):
-        check_cholesky_inputs(A)
+        _check_cholesky_inputs(A)
     
     A = np.array([1., 2.])
     with pytest.raises(AssertionError):
-        check_cholesky_inputs(A)
+        _check_cholesky_inputs(A)
         
     A = np.array([[1., 2., 3.], [4., 5., 6.]])
     with pytest.raises(AssertionError):
-        check_cholesky_inputs(A)
+        _check_cholesky_inputs(A)
     
     input_matrix = np.array([[-1., 2., 2.], [2., 3., 2.], [2., 2., -3.]])
     with pytest.raises(linalg.LinAlgError):
-        check_cholesky_inputs(input_matrix)
+        _check_cholesky_inputs(input_matrix)
 
 def test_jit_cholesky():
     "Tests the stabilized Cholesky decomposition routine"


### PR DESCRIPTION
Implements pivoted Cholesky decomposition as a method for handling the emulator nugget. If this option is chosen, the Cholesky factorization uses pivoting to avoid problems with singular matrices and automatically ignores points that are numerically similar enough to others such that the covariance matrix is nearly singular. Addresses issue #9.

Changes in this PR:

* Implements pivoted Cholesky decomposition in the `linalg/cholesky.py` file, plus a function for inverting pivot matrices.
* Modifications to the `GaussianProcess` class to allow pivoting as an option through setting the `nugget` attribute.
* Additional changes were required to re-order the inputs/targets to use the cached factorized covariance matrix (as the rows/columns have been re-arranged due to pivoting). This is done using the pivot matrix and its transpose as indices where appropriate in all calls to the `cho_solve` function -- once to rearrange the RHS before solving using the pivot, and again after solving with the transpose to return to the ordering in the original data.
* Includes a benchmark to illustrate how pivoting improves performance on problems with duplicate input/target values.
* Updates to documentation to reflect the above changes.