### PR TITLE
Feature/mogp fitting

### DIFF
--- a/mogp_emulator/GaussianProcess.py
+++ b/mogp_emulator/GaussianProcess.py
@@ -837,10 +837,10 @@ class GaussianProcess(object):
             testing = np.reshape(testing, (-1, 1))
         elif testing.ndim == 1:
             testing = np.reshape(testing, (1, len(testing)))
-        assert testing.ndim == 2
+        assert testing.ndim == 2, "testing must be a 2D array"
 
         n_testing, D = np.shape(testing)
-        assert D == self.D
+        assert D == self.D, "second dimension of testing must be the same as the number of input parameters"
 
         switch = self.mean.get_n_params(testing)
         mtest = self.mean.mean_f(testing, self.theta[:switch])

--- a/mogp_emulator/GaussianProcess.py
+++ b/mogp_emulator/GaussianProcess.py
@@ -449,7 +449,11 @@ class GaussianProcess(object):
         :type theta: ndarray
         :returns: None
         """
-        self.fit(theta)
+        if theta is None:
+            self._theta = None
+            self.current_logpost = None
+        else:
+            self.fit(theta)
 
     @property
     def priors(self):

--- a/mogp_emulator/MultiOutputGP.py
+++ b/mogp_emulator/MultiOutputGP.py
@@ -191,6 +191,31 @@ class MultiOutputGP(object):
 
         return PredictResult(mean=predict_unpacked, unc=unc_unpacked, deriv=deriv_unpacked)
 
+    def get_indices_fit(self):
+        """Returns the indices of the emulators that have been fit
+
+        When a ``MultiOutputGP`` class is initialized, none of the
+        emulators are fit. Fitting is done by passing the object to an
+        external fitting routine, which modifies the object to fit the
+        hyperparameters. Any emulators where the fitting fails are
+        returned to the initialized state, and this method is used to
+        determine the indices of the emulators that have succesfully
+        been fit.
+
+        Returns a list of non-negative integers indicating the
+        indices of the emulators that have been fit.
+
+        :returns: List of integer indicies indicating the emulators
+                  that have been fit. If no emulators have been
+                  fit, returns an empty list.
+        :rtype: list of int
+
+        """
+
+        return [idx for (failed_fit, idx)
+                in zip([em.theta is None for em in self.emulators],
+                       list(range(len(self.emulators)))) if not failed_fit]
+    
     def get_indices_not_fit(self):
         """Returns the indices of the emulators that have not been fit
 
@@ -214,6 +239,31 @@ class MultiOutputGP(object):
         return [idx for (failed_fit, idx)
                 in zip([em.theta is None for em in self.emulators],
                        list(range(len(self.emulators)))) if failed_fit]
+
+    def get_emulators_fit(self):
+        """Returns the emulators that have been fit
+
+        When a ``MultiOutputGP`` class is initialized, none of the
+        emulators are fit. Fitting is done by passing the object to an
+        external fitting routine, which modifies the object to fit the
+        hyperparameters. Any emulators where the fitting fails are
+        returned to the initialized state, and this method is used to
+        obtain a list of emulators that have successfully been fit.
+
+        Returns a list of ``GaussianProcess`` objects which have been
+        fit (i.e. those which have a current valid set of
+        hyperparameters).
+
+        :returns: List of ``GaussianProcess`` objects indicating the
+                  emulators that have been fit. If no emulators
+                  have been fit, returns an empty list.
+        :rtype: list of ``GaussianProcess`` objects
+
+        """
+
+        return [gpem for (failed_fit, gpem)
+                in zip([em.theta is None for em in self.emulators],
+                       self.emulators) if not failed_fit]
 
     def get_emulators_not_fit(self):
         """Returns the indices of the emulators that have not been fit

--- a/mogp_emulator/MultiOutputGP.py
+++ b/mogp_emulator/MultiOutputGP.py
@@ -344,15 +344,54 @@ class MultiOutputGP(object):
 
 
 def _gp_predict_default_NaN(gp, testing, unc, deriv, include_nugget):
-    """Wrapper function for the ``GaussianProcess`` predict method that
+    """Prediction method for GPs that defaults to NaN for unfit GPs
+
+    Wrapper function for the ``GaussianProcess`` predict method that
     returns NaN if the GP is not fit. Allows ``MultiOutputGP`` objects
     that do not have all emulators fit to still return predictions
-    with unfit emulator predictions replaced with NaN
+    with unfit emulator predictions replaced with NaN.
+
+    The first argument to this function is the GP that will be used
+    for prediction. All other arguments are the same as the
+    arguments for the ``predict`` method of ``GaussianProcess``.
+
+    :param gp: The ``GaussianProcess`` object (or related class) for
+               which predictions will be made.
+    :type gp: GaussianProcess
+    :param testing: Array-like object holding the points where
+                    predictions will be made.  Must have shape
+                    ``(n_predict, D)`` or ``(D,)`` (for a single
+                    prediction)
+    :type testing: ndarray
+    :param unc: (optional) Flag indicating if the uncertainties
+                are to be computed.  If ``False`` the method
+                returns ``None`` in place of the uncertainty
+                array. Default value is ``True``.
+    :type unc: bool
+    :param deriv: (optional) Flag indicating if the derivatives
+                  are to be computed.  If ``False`` the method
+                  returns ``None`` in place of the derivative
+                  array. Default value is ``True``.
+    :type deriv: bool
+    :param include_nugget: (optional) Flag indicating if the
+                           nugget should be included in the
+                           predictive variance. Only relevant if
+                           ``unc = True``.  Default is ``True``.
+    :type include_nugget: bool
+    :returns: Tuple of numpy arrays holding the predictions,
+              uncertainties, and derivatives,
+              respectively. Predictions and uncertainties have
+              shape ``(n_predict,)`` while the derivatives have
+              shape ``(n_predict, D)``. If the ``unc`` or
+              ``deriv`` flags are set to ``False``, then those
+              arrays are replaced by ``None``.
+    :rtype: tuple
     """
     
+    assert isinstance(gp, GaussianProcess)
+
     try:
-        return GaussianProcess.predict(gp, testing, unc, deriv,
-                                              include_nugget)
+        return gp.predict(testing, unc, deriv, include_nugget)
     except ValueError:
         
         n_predict = testing.shape[0]

--- a/mogp_emulator/MultiOutputGP.py
+++ b/mogp_emulator/MultiOutputGP.py
@@ -97,7 +97,7 @@ class MultiOutputGP(object):
 
 
     def predict(self, testing, unc=True, deriv=True, include_nugget=True,
-                allow_not_fit=True, processes=None):
+                allow_not_fit=False, processes=None):
         """Make a prediction for a set of input vectors
 
         Makes predictions for each of the emulators on a given set of
@@ -123,6 +123,14 @@ class MultiOutputGP(object):
         uncertainties should include the nugget. By default, this is
         set to ``True``.
 
+        The ``allow_not_fit`` flag determines how the object handles
+        any emulators that do not have fit hyperparameter values
+        (because fitting presumably failed). By default,
+        ``allow_not_fit=False`` and the method will raise an error
+        if any emulators are not fit. Passing ``allow_not_fit=True``
+        will override this and ``NaN`` will be returned from any
+        emulators that have not been fit.
+
         As with the fitting, this computation can be done
         independently for each emulator and thus can be done in
         parallel.
@@ -147,6 +155,12 @@ class MultiOutputGP(object):
                                 predictive variance. Only relevant if
                                 ``unc = True``.  Default is ``True``.
         :type include_nugget: bool
+        :param allow_not_fit: (optional) Flag that allows predictions
+                              to be made even if not all emulators have
+                              been fit. Default is ``False`` which
+                              will raise an error if any unfitted
+                              emulators are present.
+        :type allow_not_fit: bool
         :param processes: (optional) Number of processes to use when
                           making the predictions.  Must be a positive
                           integer or ``None`` to use the number of

--- a/mogp_emulator/MultiOutputGP.py
+++ b/mogp_emulator/MultiOutputGP.py
@@ -7,24 +7,28 @@ from mogp_emulator.Kernel import Kernel, SquaredExponential, Matern52
 from mogp_emulator.Priors import Prior
 
 class MultiOutputGP(object):
-    """
-    Implementation of a multiple-output Gaussian Process Emulator.
+    """Implementation of a multiple-output Gaussian Process Emulator.
 
-    Essentially a parallelized wrapper for the predict method. To fit in parallel, use the fit_GP_MAP
-    routine
+    Essentially a parallelized wrapper for the predict method. To fit
+    in parallel, use the ``fit_GP_MAP`` routine
 
-    Required arguments are ``inputs`` and ``targets``, both of which must be numpy arrays. ``inputs``
-    can be 1D or 2D (if 1D, assumes second axis has length 1). ``targets`` can be 1D or 2D (if 2D,
+    Required arguments are ``inputs`` and ``targets``, both of which
+    must be numpy arrays. ``inputs`` can be 1D or 2D (if 1D, assumes
+    second axis has length 1). ``targets`` can be 1D or 2D (if 2D,
     assumes a single emulator and the first axis has length 1).
 
-    Optional arguments specify how each individual emulator is constructed, including the mean
-    function, kernel, priors, and how to handle the nugget. Each argument can take values allowed
-    by the base ``GaussianProcess`` class, in which case all emulators are assumed to use the
-    same value. Any of these arguments can alternatively be a list of values with length matching
-    the number of emulators to set those values individually.
+    Optional arguments specify how each individual emulator is
+    constructed, including the mean function, kernel, priors, and how
+    to handle the nugget. Each argument can take values allowed by the
+    base ``GaussianProcess`` class, in which case all emulators are
+    assumed to use the same value. Any of these arguments can
+    alternatively be a list of values with length matching the number
+    of emulators to set those values individually.
 
-    Additional keyword arguments include ``inputdict``, and ``use_patsy``, which control how strings
-    are parsed to mean functions, if using.
+    Additional keyword arguments include ``inputdict``, and
+    ``use_patsy``, which control how strings are parsed to mean
+    functions, if using.
+
     """
 
     def __init__(self, inputs, targets, mean=None, kernel=SquaredExponential(), priors=None,
@@ -67,7 +71,7 @@ class MultiOutputGP(object):
         if issubclass(type(kernel), Kernel):
             kernel = self.n_emulators*[kernel]
 
-        assert isinstance(kernel, list), "kernel must be a Kernal subclass or a list of Kernel subclasses"
+        assert isinstance(kernel, list), "kernel must be a Kernel subclass or a list of Kernel subclasses"
         assert len(kernel) == self.n_emulators
 
         if priors is None:
@@ -93,55 +97,72 @@ class MultiOutputGP(object):
 
 
     def predict(self, testing, unc=True, deriv=True, include_nugget=True, processes=None):
-        """
-        Make a prediction for a set of input vectors
+        """Make a prediction for a set of input vectors
 
-        Makes predictions for each of the emulators on a given set of input vectors. The
-        input vectors must be passed as a ``(n_predict, D)`` or ``(D,)`` shaped array-like
-        object, where ``n_predict`` is the number of different prediction points under
-        consideration and ``D`` is the number of inputs to the emulator. If the prediction
-        inputs array has shape ``(D,)``, then the method assumes ``n_predict == 1``.
-        The prediction points are passed to each emulator and the predictions are collected
-        into an ``(n_emulators, n_predict)`` shaped numpy array as the first return value
-        from the method.
+        Makes predictions for each of the emulators on a given set of
+        input vectors. The input vectors must be passed as a
+        ``(n_predict, D)`` or ``(D,)`` shaped array-like object, where
+        ``n_predict`` is the number of different prediction points
+        under consideration and ``D`` is the number of inputs to the
+        emulator. If the prediction inputs array has shape ``(D,)``,
+        then the method assumes ``n_predict == 1``.  The prediction
+        points are passed to each emulator and the predictions are
+        collected into an ``(n_emulators, n_predict)`` shaped numpy
+        array as the first return value from the method.
 
-        Optionally, the emulator can also calculate the uncertainties in the predictions
-        (as a variance) and the derivatives with respect to each input parameter. If the
-        uncertainties are computed, they are returned as the second output from the method
-        as an ``(n_emulators, n_predict)`` shaped numpy array. If the derivatives are
-        computed, they are returned as the third output from the method as an
-        ``(n_emulators, n_predict, D)`` shaped numpy array. Finally, if uncertainties
-        are computed, the ``include_nugget`` flag determines if the uncertainties should
-        include the nugget. By default, this is set to ``True``.
+        Optionally, the emulator can also calculate the uncertainties
+        in the predictions (as a variance) and the derivatives with
+        respect to each input parameter. If the uncertainties are
+        computed, they are returned as the second output from the
+        method as an ``(n_emulators, n_predict)`` shaped numpy
+        array. If the derivatives are computed, they are returned as
+        the third output from the method as an ``(n_emulators,
+        n_predict, D)`` shaped numpy array. Finally, if uncertainties
+        are computed, the ``include_nugget`` flag determines if the
+        uncertainties should include the nugget. By default, this is
+        set to ``True``.
 
-        As with the fitting, this computation can be done independently for each emulator
-        and thus can be done in parallel.
+        As with the fitting, this computation can be done
+        independently for each emulator and thus can be done in
+        parallel.
 
-        :param testing: Array-like object holding the points where predictions will be made.
-                        Must have shape ``(n_predict, D)`` or ``(D,)`` (for a single prediction)
+        :param testing: Array-like object holding the points where
+                        predictions will be made.  Must have shape
+                        ``(n_predict, D)`` or ``(D,)`` (for a single
+                        prediction)
         :type testing: ndarray
-        :param unc: (optional) Flag indicating if the uncertainties are to be computed.
-                    If ``False`` the method returns ``None`` in place of the uncertainty
+        :param unc: (optional) Flag indicating if the uncertainties
+                    are to be computed.  If ``False`` the method
+                    returns ``None`` in place of the uncertainty
                     array. Default value is ``True``.
+
         :type unc: bool
-        :param deriv: (optional) Flag indicating if the derivatives are to be computed.
-                      If ``False`` the method returns ``None`` in place of the derivative
+        :param deriv: (optional) Flag indicating if the derivatives
+                      are to be computed.  If ``False`` the method
+                      returns ``None`` in place of the derivative
                       array. Default value is ``True``.
         :type deriv: bool
-        :param include_nugget: (optional) Flag indicating if the nugget should be included
-                               in the predictive variance. Only relevant if ``unc = True``.
-                               Default is ``True``.
+        :param include_nugget: (optional) Flag indicating if the
+                               nugget should be included in the
+                               predictive variance. Only relevant if
+                               ``unc = True``.  Default is ``True``.
         :type include_nugget: bool
-        :param processes: (optional) Number of processes to use when making the predictions.
-                          Must be a positive integer or ``None`` to use the number of
-                          processors on the computer (default is ``None``)
+        :param processes: (optional) Number of processes to use when
+                          making the predictions.  Must be a positive
+                          integer or ``None`` to use the number of
+                          processors on the computer (default is
+                          ``None``)
         :type processes: int or None
-        :returns: Tuple of numpy arrays holding the predictions, uncertainties, and derivatives,
-                  respectively. Predictions and uncertainties have shape ``(n_emulators, n_predict)``
-                  while the derivatives have shape ``(n_emulators, n_predict, D)``. If
-                  the ``do_unc`` or ``do_deriv`` flags are set to ``False``, then those arrays
-                  are replaced by ``None``.
+        :returns: Tuple of numpy arrays holding the predictions,
+                  uncertainties, and derivatives,
+                  respectively. Predictions and uncertainties have
+                  shape ``(n_emulators, n_predict)`` while the
+                  derivatives have shape ``(n_emulators, n_predict,
+                  D)``. If the ``do_unc`` or ``do_deriv`` flags are
+                  set to ``False``, then those arrays are replaced by
+                  ``None``.
         :rtype: tuple
+
         """
 
         testing = np.array(testing)
@@ -170,24 +191,73 @@ class MultiOutputGP(object):
 
         return PredictResult(mean=predict_unpacked, unc=unc_unpacked, deriv=deriv_unpacked)
 
-    def __call__(self, testing):
-        """
-        Interface to predict means by calling the object
+    def get_indices_not_fit(self):
+        """Returns the indices of the emulators that have not been fit
 
-        A MultiOutputGP object is callable, which makes predictions of the mean only
-        for a given set of inputs. Works similarly to the same method of the base GP
-        class. Predictions are made in parallel using the number of available processors.
+        When a ``MultiOutputGP`` class is initialized, none of the
+        emulators are fit. Fitting is done by passing the object to an
+        external fitting routine, which modifies the object to fit the
+        hyperparameters. Any emulators where the fitting fails are
+        returned to the initialized state, and this method is used to
+        determine the indices of the emulators that have not been fit.
+
+        Returns a list of non-negative integers indicating the
+        indices of the emulators that have not been fit.
+
+        :returns: List of integer indicies indicating the emulators
+                  that have not been fit. If all emulators have been
+                  fit, returns an empty list.
+        :rtype: list of int
+
+        """
+
+        return [idx for (failed_fit, idx)
+                in zip([em.theta is None for em in self.emulators],
+                       list(range(len(self.emulators)))) if failed_fit]
+
+    def get_emulators_not_fit(self):
+        """Returns the indices of the emulators that have not been fit
+
+        When a ``MultiOutputGP`` class is initialized, none of the
+        emulators are fit. Fitting is done by passing the object to an
+        external fitting routine, which modifies the object to fit the
+        hyperparameters. Any emulators where the fitting fails are
+        returned to the initialized state, and this method is used to
+        obtain a list of emulators that have not been fit.
+
+        Returns a list of ``GaussianProcess`` objects which have
+        not been fit (i.e. those which do not have a current set of
+        hyperparameters).
+
+        :returns: List of ``GaussianProcess`` objects indicating the
+                  emulators that have not been fit. If all emulators
+                  have been fit, returns an empty list.
+        :rtype: list of ``GaussianProcess`` objects
+
+        """
+
+        return [gpem for (failed_fit, gpem)
+                in zip([em.theta is None for em in self.emulators],
+                       self.emulators) if failed_fit]
+
+        
+    def __call__(self, testing):
+        """Interface to predict means by calling the object
+
+        A MultiOutputGP object is callable, which makes predictions of
+        the mean only for a given set of inputs. Works similarly to
+        the same method of the base GP class. Predictions are made in
+        parallel using the number of available processors.
         """
 
         return self.predict(testing, unc=False, deriv=False, processes=None)[0]
 
     def __str__(self):
-        """
-        Returns a string representation of the model
+        """Returns a string representation of the model
 
-        :returns: A string representation of the model (indicates number of sub-components
-                  and array shapes)
-        :rtype: str
+        :returns: A string representation of the model (indicates
+                  number of sub-components and array shapes) :rtype:
+                  str
         """
 
         return ("Multi-Output Gaussian Process with:\n"+

--- a/mogp_emulator/tests/test_MultiOutputGP.py
+++ b/mogp_emulator/tests/test_MultiOutputGP.py
@@ -96,20 +96,23 @@ def test_MultiOutputGP_predict(x, y, dx):
 
         assert_allclose(var[i], var_expect)
 
+    # test behavior if not all emulators are fit
+    
     gp.emulators[1].theta = None
 
-    mu, var, deriv = gp.predict(x_test)
+    mu, var, deriv = gp.predict(x_test, allow_not_fit=True)
     assert np.all(np.isnan(mu[1]))
     assert np.all(np.isnan(var[1]))
     assert np.all(np.isnan(deriv[1]))
 
-    mu, var, deriv = gp.predict(x_test, unc=False, deriv=False)
+    mu, var, deriv = gp.predict(x_test, unc=False, deriv=False,
+                                allow_not_fit=True)
     assert np.all(np.isnan(mu[1]))
     assert var is None
     assert deriv is None
 
     with pytest.raises(ValueError):
-        gp.predict(x_test, allow_not_fit=False)
+        gp.predict(x_test)
 
 
 def test_MultiOutputGP_check(x, y):

--- a/mogp_emulator/tests/test_MultiOutputGP.py
+++ b/mogp_emulator/tests/test_MultiOutputGP.py
@@ -96,18 +96,29 @@ def test_MultiOutputGP_predict(x, y, dx):
 
         assert_allclose(var[i], var_expect)
 
-def test_MultiOutputGP_get_failures(x, y):
-    "test the methods of MultiOutputGP that extracts GPs that have not been fit"
+def test_MultiOutputGP_check(x, y):
+    """test the methods of MultiOutputGP that extracts GPs that have or
+    have not been fit (or their indices)
+    """
 
     gp = MultiOutputGP(x, y, nugget=0.)
     theta = np.ones(gp.emulators[0].n_params)
 
+    assert gp.get_indices_fit() == []
+    assert gp.get_indices_not_fit() == [0, 1]
+    assert len(gp.get_emulators_fit()) == 0
+    assert len(gp.get_emulators_not_fit()) == 2
+    
     gp.emulators[0].fit(theta)
 
+    assert gp.get_indices_fit() == [0]
     assert gp.get_indices_not_fit() == [1]
+    assert len(gp.get_emulators_fit()) == 1
     assert len(gp.get_emulators_not_fit()) == 1
 
     gp.emulators[1].fit(theta)
 
+    assert gp.get_indices_fit() == [0, 1]
     assert gp.get_indices_not_fit() == []
+    assert len(gp.get_emulators_fit()) == 2
     assert len(gp.get_emulators_not_fit()) == 0

--- a/mogp_emulator/tests/test_MultiOutputGP.py
+++ b/mogp_emulator/tests/test_MultiOutputGP.py
@@ -95,3 +95,19 @@ def test_MultiOutputGP_predict(x, y, dx):
         var_expect = np.exp(theta[-2]) - np.diag(np.dot(Ktest, np.linalg.solve(K, Ktest.T)))
 
         assert_allclose(var[i], var_expect)
+
+def test_MultiOutputGP_get_failures(x, y):
+    "test the methods of MultiOutputGP that extracts GPs that have not been fit"
+
+    gp = MultiOutputGP(x, y, nugget=0.)
+    theta = np.ones(gp.emulators[0].n_params)
+
+    gp.emulators[0].fit(theta)
+
+    assert gp.get_indices_not_fit() == [1]
+    assert len(gp.get_emulators_not_fit()) == 1
+
+    gp.emulators[1].fit(theta)
+
+    assert gp.get_indices_not_fit() == []
+    assert len(gp.get_emulators_not_fit()) == 0

--- a/mogp_emulator/tests/test_MultiOutputGP.py
+++ b/mogp_emulator/tests/test_MultiOutputGP.py
@@ -96,6 +96,22 @@ def test_MultiOutputGP_predict(x, y, dx):
 
         assert_allclose(var[i], var_expect)
 
+    gp.emulators[1].theta = None
+
+    mu, var, deriv = gp.predict(x_test)
+    assert np.all(np.isnan(mu[1]))
+    assert np.all(np.isnan(var[1]))
+    assert np.all(np.isnan(deriv[1]))
+
+    mu, var, deriv = gp.predict(x_test, unc=False, deriv=False)
+    assert np.all(np.isnan(mu[1]))
+    assert var is None
+    assert deriv is None
+
+    with pytest.raises(ValueError):
+        gp.predict(x_test, allow_not_fit=False)
+
+
 def test_MultiOutputGP_check(x, y):
     """test the methods of MultiOutputGP that extracts GPs that have or
     have not been fit (or their indices)

--- a/mogp_emulator/tests/test_fitting.py
+++ b/mogp_emulator/tests/test_fitting.py
@@ -110,6 +110,17 @@ def test_fit_GP_MAP_MOGP():
 
     gp = fit_GP_MAP(x, y, theta0=[None, np.zeros(3)])
 
+    # test re-fitting
+
+    gp = MultiOutputGP(x, y)
+    gp.emulators[0].fit(np.ones(3))
+
+    gp = fit_GP_MAP(gp, theta0=np.zeros(3), n_tries=1, refit=False)
+    assert_allclose(gp.emulators[0].theta, np.ones(3))
+    assert not gp.emulators[1].theta is None
+
+    gp = fit_GP_MAP(gp, theta0=np.zeros(3), n_tries=1, refit=True)
+    assert not np.allclose(gp.emulators[0].theta, np.ones(3))
 
 def test_fit_GP_MAP_MOGP_failures():
     "test situations where mogp fitting should fail"
@@ -240,12 +251,24 @@ def test_fit_MOGP_MAP():
 
     # pass various theta0 arguments
 
-    gp = fit_GP_MAP(gp, theta0=np.zeros(3))
+    gp = _fit_MOGP_MAP(gp, theta0=np.zeros(3))
 
-    gp = fit_GP_MAP(gp, theta0=np.zeros((2, 3)))
+    gp = _fit_MOGP_MAP(gp, theta0=np.zeros((2, 3)))
 
-    gp = fit_GP_MAP(gp, theta0=[None, np.zeros(3)])
+    gp = _fit_MOGP_MAP(gp, theta0=[None, np.zeros(3)])
 
+    # test re-fitting
+
+    gp = MultiOutputGP(x, y)
+    gp.emulators[0].fit(np.ones(3))
+
+    gp = _fit_MOGP_MAP(gp, theta0=np.zeros(3), n_tries=1, refit=False)
+    assert_allclose(gp.emulators[0].theta, np.ones(3))
+    assert not gp.emulators[1].theta is None
+
+    gp = _fit_MOGP_MAP(gp, theta0=np.zeros(3), n_tries=1, refit=True)
+    assert not np.allclose(gp.emulators[0].theta, np.ones(3))
+    
 
 def test_fit_MOGP_MAP_failures():
     "test situations where fitting should fail"

--- a/mogp_emulator/tests/test_fitting.py
+++ b/mogp_emulator/tests/test_fitting.py
@@ -54,7 +54,7 @@ def test_fit_GP_MAP_failures():
     gp = GaussianProcess(x, y, nugget=0.)
 
     with pytest.raises(RuntimeError):
-        fit_GP_MAP(gp, n_tries=1)
+        fit_GP_MAP(gp, theta0=np.array([0., 0., 0.]), n_tries=1)
 
     with pytest.raises(RuntimeError):
         fit_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
@@ -123,16 +123,16 @@ def test_fit_GP_MAP_MOGP_failures():
     
     # minimization fails
 
-    with pytest.raises(RuntimeError):
-        fit_GP_MAP(gp, n_tries=1, theta0=-10000.*np.ones(3))
+    gp = fit_GP_MAP(gp, n_tries=1, theta0=-10000.*np.ones(3))
+    assert gp.get_indices_not_fit() == [0, 1]
 
     gp = MultiOutputGP(x, y, nugget=0.)
 
-    with pytest.raises(RuntimeError):
-        fit_GP_MAP(gp, n_tries=1)
+    gp = fit_GP_MAP(gp, theta0=np.array([0., 0., 0.]), n_tries=1)
+    assert gp.get_indices_not_fit() == [0, 1]
 
-    with pytest.raises(RuntimeError):
-        fit_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
+    gp = fit_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
+    assert gp.get_indices_not_fit() == [0, 1]
 
     # bad inputs
 
@@ -193,16 +193,16 @@ def test_fit_single_GP_MAP_failures():
 
     # minimization fails
 
-    with pytest.raises(RuntimeError):
-        _fit_single_GP_MAP(gp, n_tries=1, theta0=-10000.*np.ones(3))
+    gp = _fit_single_GP_MAP(gp, n_tries=1, theta0=-10000.*np.ones(3))
+    assert gp.theta is None
 
     gp = GaussianProcess(x, y, nugget=0.)
 
-    with pytest.raises(RuntimeError):
-        _fit_single_GP_MAP(gp, n_tries=1)
+    gp = _fit_single_GP_MAP(gp, theta0 = np.array([0., 0., 0.]), n_tries=1)
+    assert gp.theta is None
 
-    with pytest.raises(RuntimeError):
-        _fit_single_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
+    gp =_fit_single_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
+    assert gp.theta is None
 
     # bad inputs
 
@@ -259,16 +259,16 @@ def test_fit_MOGP_MAP_failures():
     
     # minimization fails
 
-    with pytest.raises(RuntimeError):
-        _fit_MOGP_MAP(gp, n_tries=1, theta0=-10000.*np.ones(3))
-
+    gp = _fit_MOGP_MAP(gp, n_tries=1, theta0=-10000.*np.ones(3))
+    assert gp.get_indices_not_fit() == [0, 1]
+        
     gp = MultiOutputGP(x, y, nugget=0.)
 
-    with pytest.raises(RuntimeError):
-        _fit_MOGP_MAP(gp, n_tries=1)
+    gp = _fit_MOGP_MAP(gp, theta0=np.array([0., 0., 0.]), n_tries=1)
+    assert gp.get_indices_not_fit() == [0, 1]
 
-    with pytest.raises(RuntimeError):
-        _fit_MOGP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
+    gp = _fit_MOGP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
+    assert gp.get_indices_not_fit() == [0, 1]
 
     # bad inputs
 

--- a/mogp_emulator/tests/test_fitting.py
+++ b/mogp_emulator/tests/test_fitting.py
@@ -137,13 +137,25 @@ def test_fit_GP_MAP_MOGP_failures():
     gp = fit_GP_MAP(gp, n_tries=1, theta0=-10000.*np.ones(3))
     assert gp.get_indices_not_fit() == [0, 1]
 
+    with pytest.raises(RuntimeError):
+        gp = fit_GP_MAP(gp, n_tries=1, theta0=-10000.*np.ones(3),
+                        skip_failures=False, refit=True)
+
     gp = MultiOutputGP(x, y, nugget=0.)
 
     gp = fit_GP_MAP(gp, theta0=np.array([0., 0., 0.]), n_tries=1)
     assert gp.get_indices_not_fit() == [0, 1]
 
+    with pytest.raises(RuntimeError):
+        gp = fit_GP_MAP(gp, theta0=np.array([0., 0., 0.]), n_tries=1,
+                        skip_failures=False, refit=True)
+
     gp = fit_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1)
     assert gp.get_indices_not_fit() == [0, 1]
+
+    with pytest.raises(RuntimeError):
+        gp = fit_GP_MAP(gp, theta0 = np.array([800., 0., 0.]), n_tries=1,
+                        skip_failures=False, refit=True)
 
     # bad inputs
 


### PR DESCRIPTION
This PR changes how `MultiOutputGP` fitting deals with failures. See issue #175 for more discussion.

Changes in this PR:

- `GaussianProcess` class can accept `None` as an option for parameters to signify the emulator is explicitly not fit.
- Modifications to `MultiOutputGP` class to provide information on which emulators are fit at a given time, including returning lists of indices and lists of emulators that match the fit criteria.
- Changes to `MultiOutputGP` class so that predictions of unfit emulators are replaced with `NaN`s (if desired, though this is not the default).
- Modifications to `fitting` module to provide flags for controlling fitting behavior. Options include whether to silently skip failed fits or raise an error if an emulator fails, and whether or not to refit emulators that have been previously fit.
- `fit_GP_MAP` function can provide error information on failed emulator fits even when failures are skipped.
- Tests to confirm the new options work as expected.