### PR TITLE
Feature/gpu meanfunc

### DIFF
--- a/mogp_emulator/GaussianProcessGPU.py
+++ b/mogp_emulator/GaussianProcessGPU.py
@@ -7,7 +7,7 @@ import re
 import numpy as np
 
 from mogp_emulator.Kernel import SquaredExponential, Matern52
-from mogp_emulator.MeanFunction import MeanFunction
+from mogp_emulator.MeanFunction import MeanFunction, MeanBase
 
 import mogp_emulator.LibGPGPU as LibGPGPU
 
@@ -158,20 +158,6 @@ class GaussianProcessGPU(GaussianProcessBase):
                 GPU implementation was unable to parse mean function formula {}.
                 """.format(mean.__str__())
                 )
-        # set the mean_type depending on what class our mean is
-        if isinstance( self.mean, LibGPGPU.ZeroMeanFunc):
-            self.mean_type = LibGPGPU.meanfunc_type.ZeroMean
-        elif isinstance( self.mean, LibGPGPU.FixedMeanFunc):
-            self.mean_type = LibGPGPU.meanfunc_type.FixedMean
-        elif isinstance( self.mean, LibGPGPU.ConstMeanFunc):
-            self.mean_type = LibGPGPU.meanfunc_type.ConstMean
-        elif isinstance( self.mean, LibGPGPU.PolyMeanFunc):
-            self.mean_type = LibGPGPU.meanfunc_type.PolyMean
-        else:
-            raise NotImplementedError("""
-            Only zero, fixed, const, or polynomial mean functions are implemented in GPU version.
-            """)
-
 
         self.nugget = nugget
 
@@ -204,8 +190,9 @@ class GaussianProcessGPU(GaussianProcessBase):
             self._densegp_gpu = LibGPGPU.DenseGP_GPU(self._inputs,
                                                      self._targets,
                                                      self._max_batch_size,
-                                                     self.kernel_type,
-                                                     self.mean_type)
+                                                     self.mean,
+                                                     self.kernel_type) #,
+#                                                     self.mean_type)
 
 
     @property

--- a/mogp_emulator/GaussianProcessGPU.py
+++ b/mogp_emulator/GaussianProcessGPU.py
@@ -3,8 +3,11 @@ extends GaussianProcess with an (optional) GPU implementation
 """
 
 import os
+import re
 import numpy as np
+
 from mogp_emulator.Kernel import SquaredExponential, Matern52
+from mogp_emulator.MeanFunction import MeanFunction
 
 import mogp_emulator.LibGPGPU as LibGPGPU
 
@@ -44,6 +47,61 @@ def ndarray_coerce_type_and_flags(arr):
         return arr_contiguous_float64
 
 
+def parse_meanfunc_formula(formula):
+    """
+    Assuming the formula has already been parsed by the Python MeanFunction interface,
+    we expect it to be in a standard form, with parameters denoted by 'c' and variables
+    denoted by 'x[dim_index]' where dim_index < D.
+
+    :param formula: string representing the desired mean function formula
+    :type formula: str
+
+    :returns: Instance of LibGPGPU.ConstMeanFunc or LibGPGPU.PolyMeanFunc implementing formula,
+       or None if the formula could not be parsed, or is not currently implemented in C++ code.
+    :rtype: LibGPGPU.ConstMeanFunc or LibGPGPU.PolyMeanFun or None
+    """
+    if formula == "c":
+        return LibGPGPU.ConstMeanFunc()
+    else:
+        # see if the formula is a string representation of a number
+        try:
+            m = float(formula)
+            return LibGPGPU.FixedMeanFunc(m)
+        except:
+            pass
+    # if we got here, we hopefully have a parse-able formula
+    terms = formula.split("+")
+    def find_index_and_power(term):
+        variables = re.findall("x\[[\d+]\]",term)
+        if len(variables) == 0:
+            # didn't find a non-const term
+            return None
+        indices = [int(re.search("\[([\d+])\]", v).groups()[0]) for v in variables]
+        if indices.count(indices[0]) != len(indices):
+            raise NotImplementedError("Cross terms, e.g. x[0]*x[1] not implemented in GPU version.")
+        # first guess at the power to which the index is raised is how many times it appears
+        # e.g. if written as x[0]*x[0]
+        power = len(indices)
+        # however, it's also possible to write 'x[0]^2' or even, 'x[0]*x[0]^2' or even 'x[0]^2*x[0]^2'
+        # so look at all the numbers appearing after a '^'.
+        more_powers = re.findall("\^[\d]+",term)
+        more_powers = [int(re.search("\^([\d]+)",p).groups()[0]) for p in more_powers]
+        # now add these on to the original power number
+        # (subtracting one each time, as we already have x^1 implicitly)
+        for p in more_powers:
+            power += p - 1
+        return [indices[0], power]
+    indices_powers = []
+    for term in terms:
+        ip = find_index_and_power(term)
+        if ip:
+            indices_powers.append(ip)
+    if len(indices_powers) > 0:
+        return LibGPGPU.PolyMeanFunc(indices_powers)
+    else:
+        return None
+
+
 class GaussianProcessGPU(GaussianProcessBase):
 
     """
@@ -81,20 +139,39 @@ class GaussianProcessGPU(GaussianProcessBase):
         self._targets = targets
         self._max_batch_size = max_batch_size
 
-        if mean:
-            if not (isinstance(mean, LibGPGPU.ConstMeanFunc) or \
-                    isinstance(mean, LibGPGPU.ZeroMeanFunc)):
-                raise ValueError("""
-                GPU implementation requires mean to be None, ZeroMeanFunc, or ConstMeanFunc
-                """
-                )
-            self.mean = mean
-            self.mean_type = LibGPGPU.meanfunc_type.ConstMean \
-                if isinstance(mean, LibGPGPU.ConstMeanFunc) \
-                else LibGPGPU.meanfunc_type.ZeroMean
-        else:
+        if mean is None:
             self.mean = LibGPGPU.ZeroMeanFunc()
+        else:
+            if not issubclass(type(mean), MeanBase):
+                if isinstance(mean, str):
+                    mean = MeanFunction(mean, inputdict, use_patsy)
+                else:
+                    raise ValueError("provided mean function must be a subclass of MeanBase,"+
+                                     " a string formula, or None")
+
+            # at this point, mean will definitely be a MeanBase.  We can call its __str__ and
+            # parse this to create an instance of a C++ MeanFunction
+            self.mean = parse_meanfunc_formula(mean.__str__())
+            # if we got None back from that function, something went wrong
+            if not mean:
+                raise ValueError("""
+                GPU implementation was unable to parse mean function formula {}.
+                """.format(mean.__str__())
+                )
+        # set the mean_type depending on what class our mean is
+        if isinstance( self.mean, LibGPGPU.ZeroMeanFunc):
             self.mean_type = LibGPGPU.meanfunc_type.ZeroMean
+        elif isinstance( self.mean, LibGPGPU.FixedMeanFunc):
+            self.mean_type = LibGPGPU.meanfunc_type.FixedMean
+        elif isinstance( self.mean, LibGPGPU.ConstMeanFunc):
+            self.mean_type = LibGPGPU.meanfunc_type.ConstMean
+        elif isinstance( self.mean, LibGPGPU.PolyMeanFunc):
+            self.mean_type = LibGPGPU.meanfunc_type.PolyMean
+        else:
+            raise NotImplementedError("""
+            Only zero, fixed, const, or polynomial mean functions are implemented in GPU version.
+            """)
+
 
         self.nugget = nugget
 

--- a/mogp_emulator/tests/test_GPUMeanFunction.py
+++ b/mogp_emulator/tests/test_GPUMeanFunction.py
@@ -2,14 +2,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 from ..MeanFunction import MeanFunction
-from ..LibGPGPU import (
-    gpu_usable,
-    BaseMeanFunc,
-    ZeroMeanFunc,
-    FixedMeanFunc,
-    ConstMeanFunc,
-    PolyMeanFunc
-)
+from .. import LibGPGPU
+
 from ..GaussianProcessGPU import parse_meanfunc_formula
 
 GPU_NOT_FOUND_MSG = "A compatible GPU could not be found or the GPU library (libgpgpu) could not be loaded"
@@ -34,33 +28,33 @@ def oneparams():
 def dx():
     return 1.e-6
 
-@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+@pytest.mark.skipif(not LibGPGPU.gpu_usable(), reason=GPU_NOT_FOUND_MSG)
 def test_ZeroMean(x, params):
     "test zero mean function works as expected"
-    mf = ZeroMeanFunc()
-    assert isinstance(mf, BaseMeanFunc)
+    mf = LibGPGPU.ZeroMeanFunc()
+    assert isinstance(mf, LibGPGPU.BaseMeanFunc)
     assert mf.get_n_params(x) == 0
     assert_allclose(mf.mean_f(x,np.array([])), np.zeros(2))
     assert_allclose(mf.mean_deriv(x,np.array([])), np.zeros((2,1)))
     assert_allclose(mf.mean_inputderiv(x,np.array([])), np.zeros((3,2)))
 
 
-@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+@pytest.mark.skipif(not LibGPGPU.gpu_usable(), reason=GPU_NOT_FOUND_MSG)
 def test_FixedMean(x, params):
     "test fixed mean function works as expected"
-    mf = FixedMeanFunc(22.2)
-    assert isinstance(mf, BaseMeanFunc)
+    mf = LibGPGPU.FixedMeanFunc(22.2)
+    assert isinstance(mf, LibGPGPU.BaseMeanFunc)
     assert mf.get_n_params(x) == 0
     assert_allclose(mf.mean_f(x,np.array([])), np.array([22.2,22.2]))
     assert_allclose(mf.mean_deriv(x,np.array([])), np.zeros((2,1)))
     assert_allclose(mf.mean_inputderiv(x,np.array([])), np.zeros((3,2)))
 
 
-@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+@pytest.mark.skipif(not LibGPGPU.gpu_usable(), reason=GPU_NOT_FOUND_MSG)
 def test_ConstMean(x, params):
     "test const mean function works as expected"
-    mf = ConstMeanFunc()
-    assert isinstance(mf, BaseMeanFunc)
+    mf = LibGPGPU.ConstMeanFunc()
+    assert isinstance(mf, LibGPGPU.BaseMeanFunc)
     assert mf.get_n_params(x) == 1
     param = np.array([7.])
     assert_allclose(mf.mean_f(x, param), np.array([7.,7.]))
@@ -68,13 +62,13 @@ def test_ConstMean(x, params):
     assert_allclose(mf.mean_inputderiv(x, param), np.zeros((3,2)))
 
 
-@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+@pytest.mark.skipif(not LibGPGPU.gpu_usable(), reason=GPU_NOT_FOUND_MSG)
 def test_PolyMean(x, params):
     "test polynomial mean function works as expected"
 
     # constructor takes list of lists, where inner list is a pair [index, power]
-    mf = PolyMeanFunc([[0,1],[1,1],[2,1]]) # linear in all three dimensions
-    assert isinstance(mf, BaseMeanFunc)
+    mf = LibGPGPU.PolyMeanFunc([[0,1],[1,1],[2,1]]) # linear in all three dimensions
+    assert isinstance(mf, LibGPGPU.BaseMeanFunc)
     assert mf.get_n_params(x) == 4
     param = np.array([1.,2.,3.,4.])
     expected = []
@@ -90,46 +84,46 @@ def test_PolyMean(x, params):
         assert_allclose(inputderiv_result[i], np.array((param[i+1],param[i+1])))
 
 
-@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+@pytest.mark.skipif(not LibGPGPU.gpu_usable(), reason=GPU_NOT_FOUND_MSG)
 def test_WrongNumParams(x, params):
     " test we get an informative RuntimeError if we provide the wrong number of parameters "
-    zmf = ZeroMeanFunc()
+    zmf = LibGPGPU.ZeroMeanFunc()
     with pytest.raises(RuntimeError, match=r"Expected params list of length 0"):
         zmf.mean_f(x,params)
-    fmf = FixedMeanFunc(5.)
+    fmf = LibGPGPU.FixedMeanFunc(5.)
     with pytest.raises(RuntimeError, match=r"Expected params list of length 0"):
         fmf.mean_f(x,params)
-    cmf = ConstMeanFunc()
+    cmf = LibGPGPU.ConstMeanFunc()
     with pytest.raises(RuntimeError, match=r"Expected params list of length 1"):
         cmf.mean_f(x,params)
-    pmf = PolyMeanFunc([[0,1],[1,2],[1,3]])
+    pmf = LibGPGPU.PolyMeanFunc([[0,1],[1,2],[1,3]])
     with pytest.raises(RuntimeError, match=r"Expected params list of length 4"):
         pmf.mean_f(x,params)
 
 
-@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+@pytest.mark.skipif(not LibGPGPU.gpu_usable(), reason=GPU_NOT_FOUND_MSG)
 def test_PolyBadDim(x, params):
     " test we get an informative RuntimeError if we have a polynomial term in a non-existent dimension "
-    mf = PolyMeanFunc([[0,1],[4,3]])  # dimension index 4 doesn't exist
+    mf = LibGPGPU.PolyMeanFunc([[0,1],[4,3]])  # dimension index 4 doesn't exist
     with pytest.raises(RuntimeError, match=r"Dimension index must be less than 3"):
         mf.mean_f(x,params)
 
 
-@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+@pytest.mark.skipif(not LibGPGPU.gpu_usable(), reason=GPU_NOT_FOUND_MSG)
 def test_parse_formula(x):
     mf = parse_meanfunc_formula("1.")
-    assert isinstance(mf, FixedMeanFunc)
+    assert isinstance(mf, LibGPGPU.FixedMeanFunc)
     mf = parse_meanfunc_formula("c")
-    assert isinstance(mf, ConstMeanFunc)
+    assert isinstance(mf, LibGPGPU.ConstMeanFunc)
     mf = parse_meanfunc_formula("c+c*x[0]")
-    assert isinstance(mf, PolyMeanFunc)
+    assert isinstance(mf, LibGPGPU.PolyMeanFunc)
     assert mf.get_n_params(x) == 2
     mf = parse_meanfunc_formula("c+c*x[0]+c*x[0]^2+c*x[1]")
-    assert isinstance(mf, PolyMeanFunc)
+    assert isinstance(mf, LibGPGPU.PolyMeanFunc)
     assert mf.get_n_params(x) == 4
     # try without the initial const term (should be the same
     mf = parse_meanfunc_formula("c*x[0]+c*x[0]^2+c*x[1]")
-    assert isinstance(mf, PolyMeanFunc)
+    assert isinstance(mf, LibGPGPU.PolyMeanFunc)
     assert mf.get_n_params(x) == 4
     # try with a cross term x[0]*x[1]
     with pytest.raises(NotImplementedError,

--- a/mogp_emulator/tests/test_GPUMeanFunction.py
+++ b/mogp_emulator/tests/test_GPUMeanFunction.py
@@ -1,0 +1,137 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from ..MeanFunction import MeanFunction
+from ..LibGPGPU import (
+    gpu_usable,
+    BaseMeanFunc,
+    ZeroMeanFunc,
+    FixedMeanFunc,
+    ConstMeanFunc,
+    PolyMeanFunc
+)
+from ..GaussianProcessGPU import parse_meanfunc_formula
+
+GPU_NOT_FOUND_MSG = "A compatible GPU could not be found or the GPU library (libgpgpu) could not be loaded"
+
+@pytest.fixture
+def x():
+    return np.array([[1., 2., 3.], [4., 5., 6.]])
+
+@pytest.fixture
+def params():
+    return np.array([1., 2., 4.])
+
+@pytest.fixture
+def zeroparams():
+    return np.zeros(0)
+
+@pytest.fixture
+def oneparams():
+    return np.ones(1)
+
+@pytest.fixture
+def dx():
+    return 1.e-6
+
+@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+def test_ZeroMean(x, params):
+    "test zero mean function works as expected"
+    mf = ZeroMeanFunc()
+    assert isinstance(mf, BaseMeanFunc)
+    assert mf.get_n_params(x) == 0
+    assert_allclose(mf.mean_f(x,np.array([])), np.zeros(2))
+    assert_allclose(mf.mean_deriv(x,np.array([])), np.zeros((2,1)))
+    assert_allclose(mf.mean_inputderiv(x,np.array([])), np.zeros((3,2)))
+
+
+@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+def test_FixedMean(x, params):
+    "test fixed mean function works as expected"
+    mf = FixedMeanFunc(22.2)
+    assert isinstance(mf, BaseMeanFunc)
+    assert mf.get_n_params(x) == 0
+    assert_allclose(mf.mean_f(x,np.array([])), np.array([22.2,22.2]))
+    assert_allclose(mf.mean_deriv(x,np.array([])), np.zeros((2,1)))
+    assert_allclose(mf.mean_inputderiv(x,np.array([])), np.zeros((3,2)))
+
+
+@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+def test_ConstMean(x, params):
+    "test const mean function works as expected"
+    mf = ConstMeanFunc()
+    assert isinstance(mf, BaseMeanFunc)
+    assert mf.get_n_params(x) == 1
+    param = np.array([7.])
+    assert_allclose(mf.mean_f(x, param), np.array([7.,7.]))
+    assert_allclose(mf.mean_deriv(x, param), np.ones((2,1)))
+    assert_allclose(mf.mean_inputderiv(x, param), np.zeros((3,2)))
+
+
+@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+def test_PolyMean(x, params):
+    "test polynomial mean function works as expected"
+
+    # constructor takes list of lists, where inner list is a pair [index, power]
+    mf = PolyMeanFunc([[0,1],[1,1],[2,1]]) # linear in all three dimensions
+    assert isinstance(mf, BaseMeanFunc)
+    assert mf.get_n_params(x) == 4
+    param = np.array([1.,2.,3.,4.])
+    expected = []
+    for xi in x:
+        expected.append(param[0]+param[1]*xi[0]+param[2]*xi[1]+param[3]*xi[2])
+    assert_allclose(mf.mean_f(x, param), np.array(expected))
+    deriv_result = mf.mean_deriv(x, param)
+    assert_allclose(deriv_result[0], np.ones(2))
+    for i in range(1, 4):
+        assert_allclose(deriv_result[i], np.array([x[0][i-1],x[1][i-1]]))
+    inputderiv_result = mf.mean_inputderiv(x, param)
+    for i in range(3):
+        assert_allclose(inputderiv_result[i], np.array((param[i+1],param[i+1])))
+
+
+@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+def test_WrongNumParams(x, params):
+    " test we get an informative RuntimeError if we provide the wrong number of parameters "
+    zmf = ZeroMeanFunc()
+    with pytest.raises(RuntimeError, match=r"Expected params list of length 0"):
+        zmf.mean_f(x,params)
+    fmf = FixedMeanFunc(5.)
+    with pytest.raises(RuntimeError, match=r"Expected params list of length 0"):
+        fmf.mean_f(x,params)
+    cmf = ConstMeanFunc()
+    with pytest.raises(RuntimeError, match=r"Expected params list of length 1"):
+        cmf.mean_f(x,params)
+    pmf = PolyMeanFunc([[0,1],[1,2],[1,3]])
+    with pytest.raises(RuntimeError, match=r"Expected params list of length 4"):
+        pmf.mean_f(x,params)
+
+
+@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+def test_PolyBadDim(x, params):
+    " test we get an informative RuntimeError if we have a polynomial term in a non-existent dimension "
+    mf = PolyMeanFunc([[0,1],[4,3]])  # dimension index 4 doesn't exist
+    with pytest.raises(RuntimeError, match=r"Dimension index must be less than 3"):
+        mf.mean_f(x,params)
+
+
+@pytest.mark.skipif(not gpu_usable(), reason=GPU_NOT_FOUND_MSG)
+def test_parse_formula(x):
+    mf = parse_meanfunc_formula("1.")
+    assert isinstance(mf, FixedMeanFunc)
+    mf = parse_meanfunc_formula("c")
+    assert isinstance(mf, ConstMeanFunc)
+    mf = parse_meanfunc_formula("c+c*x[0]")
+    assert isinstance(mf, PolyMeanFunc)
+    assert mf.get_n_params(x) == 2
+    mf = parse_meanfunc_formula("c+c*x[0]+c*x[0]^2+c*x[1]")
+    assert isinstance(mf, PolyMeanFunc)
+    assert mf.get_n_params(x) == 4
+    # try without the initial const term (should be the same
+    mf = parse_meanfunc_formula("c*x[0]+c*x[0]^2+c*x[1]")
+    assert isinstance(mf, PolyMeanFunc)
+    assert mf.get_n_params(x) == 4
+    # try with a cross term x[0]*x[1]
+    with pytest.raises(NotImplementedError,
+                       match=r"Cross terms, e.g. x\[0\]\*x\[1\] not implemented"):
+        mf = parse_meanfunc_formula("c+x[0]*x[1]")

--- a/mogp_gpu/Makefile
+++ b/mogp_gpu/Makefile
@@ -49,4 +49,8 @@ bin/test/gpu_cholesky: test/gpu_cholesky.cu
 	mkdir -p bin/test
 	nvcc $(CXXFLAGS) $(NVCCFLAGS) -lcusolver -lcublas $< -o $@
 
+bin/test/gpu_meanfunc: test/gpu_meanfunc.cu
+	mkdir -p bin/test
+	nvcc $(CXXFLAGS) $(NVCCFLAGS) $<  obj/util.o -o $@
+
 .PHONY: all clean

--- a/mogp_gpu/Makefile
+++ b/mogp_gpu/Makefile
@@ -49,7 +49,7 @@ bin/test/gpu_cholesky: test/gpu_cholesky.cu
 	mkdir -p bin/test
 	nvcc $(CXXFLAGS) $(NVCCFLAGS) -lcusolver -lcublas $< -o $@
 
-bin/test/gpu_meanfunc: test/gpu_meanfunc.cu
+bin/test/gpu_meanfunc: test/gpu_meanfunc.cu obj/util.o
 	mkdir -p bin/test
 	nvcc $(CXXFLAGS) $(NVCCFLAGS) $<  obj/util.o -o $@
 

--- a/mogp_gpu/src/gp_gpu.cu
+++ b/mogp_gpu/src/gp_gpu.cu
@@ -8,7 +8,7 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(libgpgpu, m) {
     py::class_<DenseGP_GPU>(m, "DenseGP_GPU")
-      .def(py::init<mat_ref, vec_ref, unsigned int, kernel_type>())
+      .def(py::init<mat_ref, vec_ref, unsigned int, kernel_type, meanfunc_type>())
 
 ////////////////////////////////////////
         .def("n", &DenseGP_GPU::get_n,
@@ -238,6 +238,19 @@ likelihood of the hyperparameters, from the current state of the emulator.)
         .def("get_n_params", &ConstMeanFunc::get_n_params,
 	     "Number of paramaters of mean function");
 
+    py::class_<ZeroMeanFunc>(m, "ZeroMeanFunc")
+      .def(py::init<>())
+
+////////////////////////////////////////
+        .def("mean_f", &ZeroMeanFunc::mean_f,
+             "Evaluate the mean function at input points")
+        .def("mean_deriv", &ZeroMeanFunc::mean_deriv,
+             "Calculate the derivative of the mean function wrt hyperparameters")
+        .def("mean_inputderiv", &ZeroMeanFunc::mean_inputderiv,
+	     "Derivative of mean function wrt inputs")
+        .def("get_n_params", &ZeroMeanFunc::get_n_params,
+	     "Number of paramaters of mean function");
+
     py::enum_<kernel_type>(m, "kernel_type")
         .value("SquaredExponential", SQUARED_EXPONENTIAL)
         .value("Matern52", MATERN52);
@@ -246,6 +259,10 @@ likelihood of the hyperparameters, from the current state of the emulator.)
         .value("adaptive", NUG_ADAPTIVE)
         .value("fixed", NUG_FIXED)
         .value("fit", NUG_FIT);
+
+    py::enum_<meanfunc_type>(m, "meanfunc_type")
+        .value("ZeroMean", ZERO_MEAN)
+        .value("ConstMean", CONST_MEAN);
 
     m.def("have_compatible_device", &have_compatible_device);
 

--- a/mogp_gpu/src/gp_gpu.cu
+++ b/mogp_gpu/src/gp_gpu.cu
@@ -225,6 +225,19 @@ likelihood of the hyperparameters, from the current state of the emulator.)
         .def("kernel_inputderiv", &Matern52Kernel::kernel_inputderiv,
 	     "Derivative of covariance matrix wrt inputs");
 
+    py::class_<ConstMeanFunc>(m, "ConstMeanFunc")
+      .def(py::init<>())
+
+////////////////////////////////////////
+        .def("mean_f", &ConstMeanFunc::mean_f,
+             "Evaluate the mean function at input points")
+        .def("mean_deriv", &ConstMeanFunc::mean_deriv,
+             "Calculate the derivative of the mean function wrt hyperparameters")
+        .def("mean_inputderiv", &ConstMeanFunc::mean_inputderiv,
+	     "Derivative of mean function wrt inputs")
+        .def("get_n_params", &ConstMeanFunc::get_n_params,
+	     "Number of paramaters of mean function");
+
     py::enum_<kernel_type>(m, "kernel_type")
         .value("SquaredExponential", SQUARED_EXPONENTIAL)
         .value("Matern52", MATERN52);

--- a/mogp_gpu/src/gp_gpu.cu
+++ b/mogp_gpu/src/gp_gpu.cu
@@ -8,7 +8,7 @@ namespace py = pybind11;
 
 PYBIND11_MODULE(libgpgpu, m) {
     py::class_<DenseGP_GPU>(m, "DenseGP_GPU")
-      .def(py::init<mat_ref, vec_ref, unsigned int, kernel_type, meanfunc_type>())
+      .def(py::init<mat_ref, vec_ref, unsigned int, BaseMeanFunc*, kernel_type>())
 
 ////////////////////////////////////////
         .def("n", &DenseGP_GPU::get_n,
@@ -203,10 +203,9 @@ likelihood of the hyperparameters, from the current state of the emulator.)
 )",
              py::arg("result"));
 
+////////////////////////////////////////
     py::class_<SquaredExponentialKernel>(m, "SquaredExponentialKernel")
       .def(py::init<>())
-
-////////////////////////////////////////
         .def("kernel_f", &SquaredExponentialKernel::kernel_f,
              "Calculate the covariance matrix")
         .def("kernel_deriv", &SquaredExponentialKernel::kernel_deriv,
@@ -214,10 +213,9 @@ likelihood of the hyperparameters, from the current state of the emulator.)
         .def("kernel_inputderiv", &SquaredExponentialKernel::kernel_inputderiv,
 	     "Derivative of covariance matrix wrt inputs");
 
+////////////////////////////////////////
     py::class_<Matern52Kernel>(m, "Matern52Kernel")
       .def(py::init<>())
-
-////////////////////////////////////////
         .def("kernel_f", &Matern52Kernel::kernel_f,
              "Calculate the covariance matrix")
         .def("kernel_deriv", &Matern52Kernel::kernel_deriv,
@@ -225,10 +223,12 @@ likelihood of the hyperparameters, from the current state of the emulator.)
         .def("kernel_inputderiv", &Matern52Kernel::kernel_inputderiv,
 	     "Derivative of covariance matrix wrt inputs");
 
-    py::class_<ConstMeanFunc>(m, "ConstMeanFunc")
-      .def(py::init<>())
+////////////////////////////////////////
+    py::class_<BaseMeanFunc>(m, "BaseMeanFunc");
 
 ////////////////////////////////////////
+    py::class_<ConstMeanFunc, BaseMeanFunc>(m, "ConstMeanFunc")
+      .def(py::init<>())
         .def("mean_f", &ConstMeanFunc::mean_f,
              "Evaluate the mean function at input points")
         .def("mean_deriv", &ConstMeanFunc::mean_deriv,
@@ -236,12 +236,35 @@ likelihood of the hyperparameters, from the current state of the emulator.)
         .def("mean_inputderiv", &ConstMeanFunc::mean_inputderiv,
 	     "Derivative of mean function wrt inputs")
         .def("get_n_params", &ConstMeanFunc::get_n_params,
-	     "Number of paramaters of mean function");
-
-    py::class_<ZeroMeanFunc>(m, "ZeroMeanFunc")
-      .def(py::init<>())
+	     "Number of parameters of mean function");
 
 ////////////////////////////////////////
+    py::class_<PolyMeanFunc, BaseMeanFunc>(m, "PolyMeanFunc")
+      .def(py::init<std::vector< std::pair<int, int> > >())
+        .def("mean_f", &PolyMeanFunc::mean_f,
+             "Evaluate the mean function at input points")
+        .def("mean_deriv", &PolyMeanFunc::mean_deriv,
+             "Calculate the derivative of the mean function wrt hyperparameters")
+        .def("mean_inputderiv", &PolyMeanFunc::mean_inputderiv,
+	     "Derivative of mean function wrt inputs")
+        .def("get_n_params", &PolyMeanFunc::get_n_params,
+	     "Number of parameters of mean function");
+
+////////////////////////////////////////
+    py::class_<FixedMeanFunc, BaseMeanFunc>(m, "FixedMeanFunc")
+      .def(py::init<REAL>())
+        .def("mean_f", &FixedMeanFunc::mean_f,
+             "Evaluate the mean function at input points")
+        .def("mean_deriv", &FixedMeanFunc::mean_deriv,
+             "Calculate the derivative of the mean function wrt hyperparameters")
+        .def("mean_inputderiv", &FixedMeanFunc::mean_inputderiv,
+	     "Derivative of mean function wrt inputs")
+        .def("get_n_params", &FixedMeanFunc::get_n_params,
+	     "Number of parameters of mean function");
+
+////////////////////////////////////////
+    py::class_<ZeroMeanFunc, BaseMeanFunc>(m, "ZeroMeanFunc")
+      .def(py::init<>())
         .def("mean_f", &ZeroMeanFunc::mean_f,
              "Evaluate the mean function at input points")
         .def("mean_deriv", &ZeroMeanFunc::mean_deriv,
@@ -249,7 +272,7 @@ likelihood of the hyperparameters, from the current state of the emulator.)
         .def("mean_inputderiv", &ZeroMeanFunc::mean_inputderiv,
 	     "Derivative of mean function wrt inputs")
         .def("get_n_params", &ZeroMeanFunc::get_n_params,
-	     "Number of paramaters of mean function");
+	     "Number of parameters of mean function");
 
     py::enum_<kernel_type>(m, "kernel_type")
         .value("SquaredExponential", SQUARED_EXPONENTIAL)
@@ -259,10 +282,6 @@ likelihood of the hyperparameters, from the current state of the emulator.)
         .value("adaptive", NUG_ADAPTIVE)
         .value("fixed", NUG_FIXED)
         .value("fit", NUG_FIT);
-
-    py::enum_<meanfunc_type>(m, "meanfunc_type")
-        .value("ZeroMean", ZERO_MEAN)
-        .value("ConstMean", CONST_MEAN);
 
     m.def("have_compatible_device", &have_compatible_device);
 

--- a/mogp_gpu/src/gp_gpu.hpp
+++ b/mogp_gpu/src/gp_gpu.hpp
@@ -24,6 +24,7 @@ These in turn use CUDA kernels defined in the file cov_gpu.cu
 
 #include "util.hpp"
 #include "kernel.hpp"
+#include "meanfunc.hpp"
 
 
 

--- a/mogp_gpu/src/meanfunc.hpp
+++ b/mogp_gpu/src/meanfunc.hpp
@@ -1,0 +1,73 @@
+#ifndef MEANFUNC_HPP
+#define MEANFUNC_HPP
+
+#include <thrust/device_ptr.h>
+#include <thrust/device_malloc.h>
+#include <thrust/device_free.h>
+#include <thrust/device_vector.h>
+#include <thrust/functional.h>
+#include <thrust/transform_reduce.h>
+
+#include "types.hpp"
+
+
+class BaseMeanFunc {
+
+public:
+
+  virtual ~BaseMeanFunc(){};
+
+  // Performs a single evaluation of the mean function at specific inputs
+  virtual vec mean_f(mat_ref xs,
+		     vec_ref params) = 0;
+
+  //Derivative wrt theta of the mean function at specific inputs
+  virtual vec mean_deriv(mat_ref xs,
+			 vec_ref params) = 0;
+
+
+  //Derivative wrt x of the mean function at specific inputs
+  virtual mat mean_inputderiv(mat_ref xs,
+			      vec_ref params) = 0;
+
+  // Return the number of parameters in the function.
+  virtual int get_n_params(mat_ref xs) = 0;
+
+};
+
+
+class ConstMeanFunc : public BaseMeanFunc {
+public:
+
+  // Constant mean function
+
+  ConstMeanFunc() {};
+
+  virtual ~ConstMeanFunc() {};
+
+  inline virtual int get_n_params(mat_ref xs) { return 1; }
+
+
+  inline virtual vec mean_f(mat_ref xs,
+			    vec_ref params) {
+    vec result = vec::Constant(xs.rows(),1,params(0));
+    return result;
+  }
+
+  inline virtual vec mean_deriv(mat_ref xs,
+				vec_ref params) {
+    vec result = vec::Constant(xs.rows(),1, 1.);
+    return result;
+  }
+
+  inline virtual mat mean_inputderiv(mat_ref xs,
+				     vec_ref params) {
+    mat result = mat::Constant(xs.cols(),xs.rows(), 0.);
+    return result;
+  }
+
+
+};
+
+
+#endif

--- a/mogp_gpu/src/meanfunc.hpp
+++ b/mogp_gpu/src/meanfunc.hpp
@@ -35,6 +35,40 @@ public:
 
 };
 
+class ZeroMeanFunc : public BaseMeanFunc {
+public:
+
+  // Zero mean function
+
+  ZeroMeanFunc() {};
+
+  virtual ~ZeroMeanFunc() {};
+
+  inline virtual int get_n_params(mat_ref xs) { return 0; }
+
+
+  inline virtual vec mean_f(mat_ref xs,
+			    vec_ref params) {
+    vec result = vec::Constant(xs.rows(),1, 0.);
+    return result;
+  }
+
+  inline virtual vec mean_deriv(mat_ref xs,
+				vec_ref params) {
+    vec result = vec::Constant(xs.rows(),1, 0.);
+    return result;
+  }
+
+  inline virtual mat mean_inputderiv(mat_ref xs,
+				     vec_ref params) {
+    mat result = mat::Constant(xs.cols(),xs.rows(), 0.);
+    return result;
+  }
+
+
+};
+
+
 
 class ConstMeanFunc : public BaseMeanFunc {
 public:

--- a/mogp_gpu/src/meanfunc.hpp
+++ b/mogp_gpu/src/meanfunc.hpp
@@ -1,6 +1,7 @@
 #ifndef MEANFUNC_HPP
 #define MEANFUNC_HPP
 
+#include <string>
 #include <vector>
 #include <utility>
 
@@ -53,18 +54,24 @@ public:
 
   inline virtual vec mean_f(mat_ref xs,
 			    vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length "+ std::to_string(get_n_params(xs)));
     vec result = vec::Constant(xs.rows(),1, 0.);
     return result;
   }
 
   inline virtual mat mean_deriv(mat_ref xs,
 				vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length "+ std::to_string(get_n_params(xs)));
     mat result = mat::Constant(xs.rows(),1, 0.);
     return result;
   }
 
   inline virtual mat mean_inputderiv(mat_ref xs,
 				     vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length "+ std::to_string(get_n_params(xs)));
     mat result = mat::Constant(xs.cols(),xs.rows(), 0.);
     return result;
   }
@@ -86,18 +93,24 @@ public:
 
   inline virtual vec mean_f(mat_ref xs,
 			    vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length "+ std::to_string(get_n_params(xs)));
     vec result = vec::Constant(xs.rows(),1, value);
     return result;
   }
 
   inline virtual mat mean_deriv(mat_ref xs,
 				vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length "+ std::to_string(get_n_params(xs)));
     mat result = mat::Constant(xs.rows(),1, 0.);
     return result;
   }
 
   inline virtual mat mean_inputderiv(mat_ref xs,
 				     vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length "+ std::to_string(get_n_params(xs)));
     mat result = mat::Constant(xs.cols(),xs.rows(), 0.);
     return result;
   }
@@ -123,18 +136,24 @@ public:
 
   inline virtual vec mean_f(mat_ref xs,
 			    vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length "+ std::to_string(get_n_params(xs)));
     vec result = vec::Constant(xs.rows(),1,params(0));
     return result;
   }
 
   inline virtual mat mean_deriv(mat_ref xs,
 				vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length "+ std::to_string(get_n_params(xs)));
     mat result = mat::Constant(xs.rows(),1, 1.);
     return result;
   }
 
   inline virtual mat mean_inputderiv(mat_ref xs,
 				     vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length "+ std::to_string(get_n_params(xs)));
     mat result = mat::Constant(xs.cols(),xs.rows(), 0.);
     return result;
   }
@@ -167,6 +186,8 @@ public:
 
   inline virtual vec mean_f(mat_ref xs,
 			    vec_ref params) {
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length " +  std::to_string(get_n_params(xs)));
     vec result(xs.rows());
     for (unsigned int i=0; i< xs.rows(); ++i) {
       // have the const term as the first parameter
@@ -174,7 +195,7 @@ public:
       for (unsigned int j=0; j< dims_powers.size(); ++j) {
 	int dim_index = dims_powers[j].first;
 	int power = dims_powers[j].second;
-	if (dim_index > xs.cols()-1) throw std::runtime_error("Dimension index must be less than D");
+	if (dim_index > xs.cols()-1) throw std::runtime_error("Dimension index must be less than "+ std::to_string(xs.cols()));
 	val += params(j+1) * pow(xs(i,dim_index), power);
       }
 
@@ -185,7 +206,8 @@ public:
 
   inline virtual mat mean_deriv(mat_ref xs,
 				vec_ref params) {
-
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length " + std::to_string(get_n_params(xs)));
     mat result(params.rows(), xs.rows());
     for (unsigned int i=0; i< xs.rows(); ++i) {
       // deriv wrt the first param (the const term) is always 1.
@@ -203,8 +225,8 @@ public:
 
   inline virtual mat mean_inputderiv(mat_ref xs,
 				     vec_ref params) {
-    //sanity check - number of parameters should be one per term (plus const term).
-    if (params.rows() != dims_powers.size() + 1) throw std::runtime_error("Incorrect number of parameters for this formula.");
+    if ( params.rows() != get_n_params(xs))
+      throw std::runtime_error("Expected params list of length " + std::to_string(get_n_params(xs)));
     mat result = mat::Constant(xs.cols(),xs.rows(), 0.);
     // loop through all inputs
     for (unsigned int i=0; i< xs.rows(); ++i) {

--- a/mogp_gpu/src/meanfunc.hpp
+++ b/mogp_gpu/src/meanfunc.hpp
@@ -1,6 +1,9 @@
 #ifndef MEANFUNC_HPP
 #define MEANFUNC_HPP
 
+#include <vector>
+#include <utility>
+
 #include <thrust/device_ptr.h>
 #include <thrust/device_malloc.h>
 #include <thrust/device_free.h>
@@ -22,7 +25,7 @@ public:
 		     vec_ref params) = 0;
 
   //Derivative wrt theta of the mean function at specific inputs
-  virtual vec mean_deriv(mat_ref xs,
+  virtual mat mean_deriv(mat_ref xs,
 			 vec_ref params) = 0;
 
 
@@ -36,6 +39,7 @@ public:
 };
 
 class ZeroMeanFunc : public BaseMeanFunc {
+
 public:
 
   // Zero mean function
@@ -53,9 +57,9 @@ public:
     return result;
   }
 
-  inline virtual vec mean_deriv(mat_ref xs,
+  inline virtual mat mean_deriv(mat_ref xs,
 				vec_ref params) {
-    vec result = vec::Constant(xs.rows(),1, 0.);
+    mat result = mat::Constant(xs.rows(),1, 0.);
     return result;
   }
 
@@ -65,12 +69,47 @@ public:
     return result;
   }
 
+};
+
+class FixedMeanFunc : public BaseMeanFunc {
+
+public:
+
+  // Fixed mean function
+
+  FixedMeanFunc(REAL value_): value(value_) {};
+
+  virtual ~FixedMeanFunc() {} ;
+
+  inline virtual int get_n_params(mat_ref xs) { return 0; }
+
+
+  inline virtual vec mean_f(mat_ref xs,
+			    vec_ref params) {
+    vec result = vec::Constant(xs.rows(),1, value);
+    return result;
+  }
+
+  inline virtual mat mean_deriv(mat_ref xs,
+				vec_ref params) {
+    mat result = mat::Constant(xs.rows(),1, 0.);
+    return result;
+  }
+
+  inline virtual mat mean_inputderiv(mat_ref xs,
+				     vec_ref params) {
+    mat result = mat::Constant(xs.cols(),xs.rows(), 0.);
+    return result;
+  }
+
+private:
+  REAL value;
 
 };
 
 
-
 class ConstMeanFunc : public BaseMeanFunc {
+
 public:
 
   // Constant mean function
@@ -88,9 +127,9 @@ public:
     return result;
   }
 
-  inline virtual vec mean_deriv(mat_ref xs,
+  inline virtual mat mean_deriv(mat_ref xs,
 				vec_ref params) {
-    vec result = vec::Constant(xs.rows(),1, 1.);
+    mat result = mat::Constant(xs.rows(),1, 1.);
     return result;
   }
 
@@ -100,6 +139,96 @@ public:
     return result;
   }
 
+
+};
+
+
+class PolyMeanFunc : public BaseMeanFunc {
+
+public:
+
+  // Polynomial mean function
+
+  // constructor takes a vector of pair<int, int>.  In each pair,
+  // the first number represents the dimension index of the input, and
+  // the second is the power to which that will be raised.
+  // So, for example, if we have 1D input, and we want a 2nd order polynomial, we would have
+  // <0,1>,<0,2>, corresponding to "theta_0 + theta_1 * x[0] + theta_2 * x[0]^2"
+  // If we have 2D input, and we want a function linear in both dimensions, we would have
+  // <0,1>, <1,1>, corresponding to "theta_0 + theta_1 * x[0] + theta_2 * x[1]"
+  // The number of parameters is always 1 greater than the number of pairs in the vector,
+  // as we allow for a const term as well as the coefficients multiplying these inputs/powers.
+  // The const term will always be the first of the parameters.
+  PolyMeanFunc(std::vector<std::pair<int,int> > dp) : dims_powers(dp) {};
+
+  virtual ~PolyMeanFunc() {};
+
+  inline virtual int get_n_params(mat_ref xs) { return dims_powers.size() + 1; }
+
+  inline virtual vec mean_f(mat_ref xs,
+			    vec_ref params) {
+    vec result(xs.rows());
+    for (unsigned int i=0; i< xs.rows(); ++i) {
+      // have the const term as the first parameter
+      REAL val = params(0);
+      for (unsigned int j=0; j< dims_powers.size(); ++j) {
+	int dim_index = dims_powers[j].first;
+	int power = dims_powers[j].second;
+	if (dim_index > xs.cols()-1) throw std::runtime_error("Dimension index must be less than D");
+	val += params(j+1) * pow(xs(i,dim_index), power);
+      }
+
+      result(i) = val;
+    }
+    return result;
+  }
+
+  inline virtual mat mean_deriv(mat_ref xs,
+				vec_ref params) {
+
+    mat result(params.rows(), xs.rows());
+    for (unsigned int i=0; i< xs.rows(); ++i) {
+      // deriv wrt the first param (the const term) is always 1.
+      result(0,i) = 1.;
+      // for the rest of the rows, evaluate x[index[j]]^pow[j]
+      for (unsigned int j=0; j< dims_powers.size(); ++j) {
+	int dim_index = dims_powers[j].first;
+	int power = dims_powers[j].second;
+	if (dim_index > xs.cols()-1) throw std::runtime_error("Dimension index must be less than D");
+	result(j+1,i) = pow(xs(i,dim_index), power);
+      }
+    }
+    return result;
+  }
+
+  inline virtual mat mean_inputderiv(mat_ref xs,
+				     vec_ref params) {
+    //sanity check - number of parameters should be one per term (plus const term).
+    if (params.rows() != dims_powers.size() + 1) throw std::runtime_error("Incorrect number of parameters for this formula.");
+    mat result = mat::Constant(xs.cols(),xs.rows(), 0.);
+    // loop through all inputs
+    for (unsigned int i=0; i< xs.rows(); ++i) {
+      // loop through all dimensions of the input
+      for (unsigned int j=0; j< xs.cols(); ++j) {
+	REAL val = 0.;
+	// loop through all terms of the formula
+	for (unsigned int k=0; k< dims_powers.size(); ++k) {
+	  int dim_index = dims_powers[k].first;
+	  int power = dims_powers[k].second;
+	  if (dim_index > xs.cols()-1) throw std::runtime_error("Dimension index must be less than D");
+	  // if this term deals with dimension j, differentiate and add to val
+	  if (dim_index == j) {
+	    val += params(k+1) * power * pow(xs(i,j),(power-1));
+	  }
+	}
+	result(j,i) = val;
+      }
+    }
+    return result;
+  }
+
+private:
+  std::vector<std::pair<int, int> > dims_powers;
 
 };
 

--- a/mogp_gpu/src/types.hpp
+++ b/mogp_gpu/src/types.hpp
@@ -32,6 +32,6 @@ enum nugget_type {NUG_ADAPTIVE, NUG_FIT, NUG_FIXED};
 enum kernel_type {SQUARED_EXPONENTIAL, MATERN52};
 
 // enum to allow python code to select mean function
-enum meanfunc_type {ZERO_MEAN, CONST_MEAN};
+enum meanfunc_type {ZERO_MEAN, FIXED_MEAN, CONST_MEAN, POLY_MEAN};
 
 #endif

--- a/mogp_gpu/src/types.hpp
+++ b/mogp_gpu/src/types.hpp
@@ -31,7 +31,4 @@ enum nugget_type {NUG_ADAPTIVE, NUG_FIT, NUG_FIXED};
 // enum to allow python code to select Kernel function
 enum kernel_type {SQUARED_EXPONENTIAL, MATERN52};
 
-// enum to allow python code to select mean function
-enum meanfunc_type {ZERO_MEAN, FIXED_MEAN, CONST_MEAN, POLY_MEAN};
-
 #endif

--- a/mogp_gpu/src/types.hpp
+++ b/mogp_gpu/src/types.hpp
@@ -31,4 +31,7 @@ enum nugget_type {NUG_ADAPTIVE, NUG_FIT, NUG_FIXED};
 // enum to allow python code to select Kernel function
 enum kernel_type {SQUARED_EXPONENTIAL, MATERN52};
 
+// enum to allow python code to select mean function
+enum meanfunc_type {ZERO_MEAN, CONST_MEAN};
+
 #endif

--- a/mogp_gpu/test/gpu_meanfunc.cu
+++ b/mogp_gpu/test/gpu_meanfunc.cu
@@ -1,0 +1,59 @@
+#include <iostream>
+
+#include <vector>
+#include <algorithm>
+#include <string>
+#include <sstream>
+#include <assert.h>
+#include <stdexcept>
+#include <cuda_runtime.h>
+#include <cublas_v2.h>
+#include <cusolverDn.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_malloc.h>
+#include <thrust/device_free.h>
+#include <thrust/device_vector.h>
+#include <thrust/functional.h>
+#include <thrust/transform_reduce.h>
+#include <thrust/copy.h>
+
+#include "../src/meanfunc.hpp"
+
+typedef double REAL;
+
+void test_const_meanfunc()
+{
+    const size_t N=5;
+    vec x(5);
+    x << 1.0, 2.0, 3.0, 4.0, 5.0;
+
+    vec params(1);
+    params << 4.4;
+
+
+    ConstMeanFunc* mf = new ConstMeanFunc();
+    vec mean = mf->mean_f(x,params);
+    vec deriv = mf->mean_deriv(x,params);
+    vec inputderiv = mf->mean_inputderiv(x,params);
+
+    std::cout<<" mean: ";
+    for (int i=0; i<N; i++)
+        std::cout << mean [i] << " ";
+    std::cout << "\n deriv: ";
+    for (int i=0; i<N; i++)
+        std::cout << deriv [i] << " ";
+    std::cout << "\n inputderiv: ";
+    for (int i=0; i<N; i++)
+        std::cout << inputderiv [i] << " ";
+    std::cout << "\n";
+
+    delete mf;
+}
+
+
+
+int main(void)
+{
+    test_const_meanfunc();
+    return 0;
+}

--- a/mogp_gpu/test/gpu_meanfunc.cu
+++ b/mogp_gpu/test/gpu_meanfunc.cu
@@ -50,10 +50,44 @@ void test_const_meanfunc()
     delete mf;
 }
 
+void test_poly_meanfunc()
+{
+  // 1D case - 2nd order polynomial
+  // mean f should be 2.2 + 4.4*x + 3.3*x^2
+    const size_t N=5;
+    vec x(5);
+    x << 1.0, 2.0, 3.0, 4.0, 5.0;
+
+    vec params(3);
+    params << 4.4, 3,3, 2.2;
+
+    std::vector< std::pair<int, int> > dims_powers;
+    dims_powers.push_back(std::make_pair<int, int>(0,1));
+    dims_powers.push_back(std::make_pair<int, int>(0,2));
+    PolyMeanFunc* mf = new PolyMeanFunc(dims_powers);
+    vec mean = mf->mean_f(x,params);
+    vec deriv = mf->mean_deriv(x,params);
+    vec inputderiv = mf->mean_inputderiv(x,params);
+
+    std::cout<<" mean: ";
+    for (int i=0; i<N; i++)
+        std::cout << mean [i] << " ";
+    std::cout << "\n deriv: ";
+    for (int i=0; i<N; i++)
+        std::cout << deriv [i] << " ";
+    std::cout << "\n inputderiv: ";
+    for (int i=0; i<N; i++)
+        std::cout << inputderiv [i] << " ";
+    std::cout << "\n";
+
+    delete mf;
+}
+
 
 
 int main(void)
 {
     test_const_meanfunc();
+    test_poly_meanfunc();
     return 0;
 }


### PR DESCRIPTION
Implement mean functions in the C++ code used for the GPU implementation.  (Note that the mean function calculations are not currently done on the GPU - they are in the C++ code executed on the CPU).
Currently implemented:
* ZeroMeanFunc (default - zero everywhere)
* FixedMeanFunc (no parameters, fixed constant value everywhere)
* ConstMeanFunc (one parameter, constant value everywhere)
* PolyMeanfunc (polynomial of any degree in any of the input dimensions, but no cross-terms (e.g. x[0]*x[1]) permitted.

* All C++ classes have pybind11 bindings to create corresponding python classes.
* The Python interface in GaussianProcessGPU uses the python MeanFunction as an argument to the GP constructor.   A function `parse_meanfunc_formula` uses the string representation of the formula from MeanFunction to create the appropriate C++ instance (i.e. it relies on the Python version having done some formula parsing to put things in a reasonably standard format).