### PR TITLE
Fix license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import numpy as np
 MAJOR = 0
 MINOR = 5
 MICRO = 0
-PRERELEASE = 3
+PRERELEASE = 4
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 
@@ -139,7 +139,7 @@ setuptools.setup(name='mogp_emulator',
       author='Alan Turing Institute Research Engineering Group',
       author_email='edaub@turing.ac.uk',
       packages=setuptools.find_packages(),
-      license=['MIT'],
+      license='MIT',
       ext_modules=ext_modules,
       cmdclass={"build_ext": custom_build_ext},
       install_requires=['numpy', 'scipy'],


### PR DESCRIPTION
Fixed up setup.py to correct error due to setuptools change. Addresses #188.

Changes in this PR:

* `setup.py` has minor fix to `license` attribute of `setuptools.setup` due to change upstream.