### PR TITLE
Start work on v0.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ import numpy as np
 
 # version information
 MAJOR = 0
-MINOR = 5
+MINOR = 6
 MICRO = 0
-PRERELEASE = 4
+PRERELEASE = 0
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Reset version number in setup.py for starting work on next release.

Changes:

- `setup.py` -- bumped version number to 0.6.0 for work on next release.