### PR TITLE
Multi-Output History Matching

### DIFF
--- a/docs/demos/multioutput_tutorial.rst
+++ b/docs/demos/multioutput_tutorial.rst
@@ -1,0 +1,27 @@
+.. _multioutput_tutorial:
+
+Multi-Output Tutorial
+=====================
+
+*Note: This tutorial requires Scipy version 1.4 or later to run the simulator.*
+
+This page includes an end-to-end example of using ``mogp_emulator`` to perform model calibration
+with a simulator with multiple outputs. Note that this builds on the main tutorial with a
+second output (in this case, the velocity of the projectile at the end of the simulation),
+which is able to further constrain the NROY space as described in the first tutorial.
+
+.. literalinclude:: ../../mogp_emulator/demos/multioutput_tutorial.py
+
+One thing to note about multiple outputs is that they must be run as a script with a 
+``if __name__ == __main__`` block in order to correctly use the multiprocessing
+library. This can usually be done as in the example for short scripts, while for more
+complex analyses it is usually better to define functions (as in the benchmark for
+multiple outputs).
+
+More Details
+------------
+
+More details about these steps can be found in the :ref:`methods` section, or on the following page
+that goes into :ref:`more details <methoddetails>` on the options available in this software library.
+For more on the specific implementation detials, see the various
+:ref:`implementation pages <implementation>` describing the software components.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ details, and some included benchmarks.
              be used are:
 
    demos/gp_demos
+   demos/multioutput_tutorial
    demos/mice_demos
    demos/historymatch_demos
    demos/kdr_demos

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -58,7 +58,7 @@ the two input parameters of the drag coefficient :math:`C` and the initial veloc
 and returning a single value, which is :math:`x` at the end of the simulation.
 
 .. literalinclude:: ../../mogp_emulator/demos/projectile.py
-   :lines: 1-3,12-43,46-
+   :lines: 1-80
 
 Parameter Space
 ~~~~~~~~~~~~~~~
@@ -131,11 +131,13 @@ by passing the GP object to the ``fit_GP_MAP`` function, which returns the same
 GP object but with the parameter values estimated.
 
 .. literalinclude:: ../../mogp_emulator/demos/tutorial.py
-   :lines: 33-37
+   :lines: 33-38
 
-While the function is called ``fit_GP_MAP`` (MAP means Maximum A Posteriori),
-in this case we have not provided any prior information on the parameter values,
-so it results in MLE.
+By default, if no priors are specified for the hyperparameters then defaults
+are chosen. In particular, for correlation lengths, default priors are fit
+that attempt to put most of the distribution mass in the range spanned by
+the input data. This tends to stabilize the fitting and improve performance,
+as fewer iterations are needed to ensure a good fit.
 
 Following fitting, we print out some of the hyperparameters that are estimated.
 First, we print out the correlation lengths estimated for each of the input
@@ -162,7 +164,7 @@ and the uncertainty. This is done with the ``predict`` method of
 :ref:`GaussianProcess <GaussianProcess>`:
 
 .. literalinclude:: ../../mogp_emulator/demos/tutorial.py
-   :lines: 44-52
+   :lines: 45-52
 
 ``predictions`` is an object containing the mean and uncertainty (variance)
 of the predictions. A GP assumes that the outputs follow a Normal Distribution,
@@ -206,7 +208,7 @@ and Monte Carlo sampling (especially in only 2 dimensions). Then, we create a
 Yet" (NROY). This is done as follows:
 
 .. literalinclude:: ../../mogp_emulator/demos/tutorial.py
-   :lines: 58-65
+   :lines: 57-65
 
 First, we set a large number of samples and draw them from the experimental design object. Then,
 We construct the :ref:`HistoryMatching <HistoryMatching>` object by giving the fit GP
@@ -226,7 +228,7 @@ surrogate model for reference. This plotting command is only executed if ``matpl
 installed:
 
 .. literalinclude:: ../../mogp_emulator/demos/tutorial.py
-   :lines: 5-10,69-
+   :lines: 5-10,68-
 
 which should make a plot that looks something like this:
 

--- a/mogp_emulator/HistoryMatching.py
+++ b/mogp_emulator/HistoryMatching.py
@@ -277,8 +277,13 @@ class HistoryMatching(object):
         Vs += discrepancy[:, np.newaxis]                # model discrepancy
         Vs += self.obs[1][:, np.newaxis]                # variance on observation
         I = (np.abs(self.obs[0][:, np.newaxis] - expectations[0]) / np.sqrt(Vs))
-        idx = np.where(np.argsort(I, axis=0) == n_obs - rank - 1)
-        self.I = I[idx]
+        # implausibility is the -rank index in the sorted array (i.e. if rank is 0,
+        # return the largest, if rank is 1, return the second largest, etc.),
+        # which can be correctly found in O(n) using partition.
+        # partition puts the kth largest element in its correct position along
+        # the selected axis, so we just need to select the kth row of the
+        # partitioned array along axis 0
+        self.I = np.partition(I, n_obs - rank - 1, axis=0)[n_obs - rank - 1]
         
         return self.I
 

--- a/mogp_emulator/MultiOutputGP.py
+++ b/mogp_emulator/MultiOutputGP.py
@@ -10,7 +10,10 @@ from mogp_emulator.GaussianProcessGPU import GaussianProcessGPU
 from mogp_emulator.Kernel import KernelBase
 from mogp_emulator.Priors import GPPriors
 
-class MultiOutputGP(object):
+class MultiOutputGPBase(object):
+    pass
+
+class MultiOutputGP(MultiOutputGPBase):
     """Implementation of a multiple-output Gaussian Process Emulator.
 
     Essentially a parallelized wrapper for the predict method. To fit

--- a/mogp_emulator/MultiOutputGP_GPU.py
+++ b/mogp_emulator/MultiOutputGP_GPU.py
@@ -5,13 +5,14 @@ from mogp_emulator.GaussianProcess import (
     GaussianProcess,
     PredictResult
 )
+from mogp_emulator.MultiOutputGP import MultiOutputGPBase
 from mogp_emulator.GaussianProcessGPU import GaussianProcessGPU, parse_meanfunc_formula
 from mogp_emulator.MeanFunction import MeanBase
 from mogp_emulator.Kernel import SquaredExponential, Matern52
 from mogp_emulator import LibGPGPU
 
 
-class MultiOutputGP_GPU(object):
+class MultiOutputGP_GPU(MultiOutputGPBase):
     """Implementation of a multiple-output Gaussian Process Emulator, using the GPU.
 
     Essentially a parallelized wrapper for the predict method. To fit

--- a/mogp_emulator/demos/multioutput_tutorial.py
+++ b/mogp_emulator/demos/multioutput_tutorial.py
@@ -1,0 +1,87 @@
+import numpy as np
+from projectile import simulator_multioutput, print_results
+import mogp_emulator
+
+try:
+    import matplotlib.pyplot as plt
+    makeplots = True
+except ImportError:
+    makeplots = False
+
+# An end-to-end tutorial illustrating model calibration with multiple outputs using mogp_emulator
+
+# First, we need to set up our experimental design. We would like our drag coefficient to be
+# on a logarithmic scale and initial velocity to be on a linear scale. However, our simulator
+# does the drag coefficient transformation for us, so we simply can specity the exponent on
+# a linear scale.
+
+# We will use a Latin Hypercube Design. To specify, we give the distribution that we would like
+# the parameter to take. By default, we assume a uniform distribution between two endpoints, which
+# we will use for this simulation.
+
+# Once we construct the design, can draw a specified number of samples as shown.
+
+if __name__ == "__main__": # this is required for multiprocessing to work correctly!
+
+    lhd = mogp_emulator.LatinHypercubeDesign([(-5., 1.), (0., 1000.)])
+
+    n_simulations = 50
+    simulation_points = lhd.sample(n_simulations)
+
+# Run simulator. For the multioutput simulator, returns (distance, velocity) pair
+
+    simulation_output = np.array([simulator_multioutput(p) for p in simulation_points]).T
+
+# Next, fit the surrogate MOGP model using MAP with the default priors
+# Print out hyperparameter values as correlation lengths and sigma
+
+    gp = mogp_emulator.MultiOutputGP(simulation_points, simulation_output, nugget="fit")
+    gp = mogp_emulator.fit_GP_MAP(gp, n_tries=2)
+
+    print("Correlation lengths (distance)= {}".format(gp.emulators[0].theta.corr))
+    print("Correlation lengths (velocity)= {}".format(gp.emulators[1].theta.corr))
+    print("Sigma (distance)= {}".format(np.sqrt(gp.emulators[0].theta.cov)))
+    print("Sigma (velocity)= {}".format(np.sqrt(gp.emulators[1].theta.cov)))
+    print("Nugget (distance)= {}".format(np.sqrt(gp.emulators[0].theta.nugget)))
+    print("Nugget (velocity)= {}".format(np.sqrt(gp.emulators[1].theta.nugget)))
+
+# Validate emulator by comparing to true simulated value
+# To compare with the emulator, use the predict method to get mean and variance
+# values for the emulator predictions and see how many are within 2 standard
+# deviations
+
+    n_valid = 10
+    validation_points = lhd.sample(n_valid)
+    validation_output = np.array([simulator_multioutput(p) for p in validation_points]).T
+
+    predictions = gp.predict(validation_points)
+
+    print_results(validation_points, predictions.mean)
+
+# Finally, perform history matching. Sample densely from the experimental design and
+# determine which points are consistent with the data using the GP predictions
+# We compute which points are "Not Ruled Out Yet" (NROY)
+
+# Note that our observations are now vectors, with the same ordering as the
+# simulation output
+
+    n_predict = 10000
+    prediction_points = lhd.sample(n_predict)
+
+    hm = mogp_emulator.HistoryMatching(gp=gp, coords=prediction_points, obs=[np.array([2000., 100.]),
+                                                                             np.array([100., 5.])])
+
+    nroy_points = hm.get_NROY(rank=0)
+
+    print("Ruled out {} of {} points".format(n_predict - len(nroy_points), n_predict))
+
+# If plotting enabled, visualize results
+
+    if makeplots:
+        plt.figure()
+        plt.plot(prediction_points[nroy_points,0], prediction_points[nroy_points,1], "o", label="NROY points")
+        plt.plot(simulation_points[:,0], simulation_points[:,1],"o", label="Simulation Points")
+        plt.xlabel("log Drag Coefficient")
+        plt.ylabel("Launch velocity (m/s)")
+        plt.legend()
+        plt.show()

--- a/mogp_emulator/demos/projectile.py
+++ b/mogp_emulator/demos/projectile.py
@@ -46,7 +46,7 @@ event.terminal = True
 
 # now can define simulator
 
-def simulator(x):
+def simulator_base(x):
     "simulator to solve ODE system for projectile motion with drag. returns distance projectile travels"
 
     # unpack values
@@ -69,7 +69,22 @@ def simulator(x):
 
     results = solve_ivp(f, (0., 1.e8), y0, events=event, args = (c,))
 
+    return results
+
+def simulator(x):
+    "simulator to solve ODE system for projectile motion with drag. returns distance projectile travels"
+
+    results = simulator_base(x)
+
     return results.y_events[0][0][2]
+
+def simulator_multioutput(x):
+    "simulator to solve ODE system with multiple outputs"
+    
+    results = simulator_base(x)
+    
+    return (results.y_events[0][0][2],
+            np.sqrt(results.y_events[0][0][0]**2 + results.y_events[0][0][1]**2))
 
 # function for printing out results
 

--- a/mogp_emulator/tests/test_HistoryMatching.py
+++ b/mogp_emulator/tests/test_HistoryMatching.py
@@ -4,6 +4,7 @@ import pytest
 from ..HistoryMatching import HistoryMatching
 from ..fitting import fit_GP_MAP
 from ..GaussianProcess import GaussianProcess, PredictResult
+from ..MultiOutputGP import MultiOutputGP
 from ..LibGPGPU import gpu_usable
 from ..GaussianProcessGPU import GaussianProcessGPU
 
@@ -283,7 +284,7 @@ def test_HistoryMatching_init():
     hm = HistoryMatching(gp=gp, obs=1., coords=coords, expectations=None, threshold=5.)
 
     assert hm.gp == gp
-    assert_allclose(hm.obs, [1., 0.])
+    assert_allclose(hm.obs, [[1.], [0.]])
     assert_allclose(hm.coords, coords)
     assert hm.expectations is None
     assert hm.ndim == 1
@@ -300,7 +301,7 @@ def test_HistoryMatching_init():
                          threshold=5.)
 
     assert hm.gp == None
-    assert_allclose(hm.obs, [1., 0.1])
+    assert_allclose(hm.obs, [[1.], [0.1]])
     assert hm.coords == None
     for a in range(3):
         assert_allclose(hm.expectations[a], expectations[a])
@@ -403,6 +404,59 @@ def test_HistoryMatching_get_implausibility():
     with pytest.raises(AssertionError):
         hm.get_implausibility(-1.)
 
+def test_HistoryMatching_get_implausibility_mogp():
+    "Test implausibility with multiple outputs"
+    
+    # correct functionality
+
+    expectations = PredictResult(mean=np.array([[2., 10.], [4., 6.]]), unc=np.array([[0.5, 0.5], [0.5, 0.5]]),
+                                 deriv=None)
+    hm = HistoryMatching(obs=[[1., 5.], 0.5], expectations=expectations)
+    I = hm.get_implausibility()
+
+    assert_allclose(I, [1., 1.])
+    assert_allclose(hm.I, [1., 1.])
+
+    I = hm.get_implausibility(1.)
+
+    assert_allclose(I, [1./np.sqrt(2.), 1./np.sqrt(2.)])
+    assert_allclose(hm.I, [1./np.sqrt(2.), 1./np.sqrt(2.)])
+    
+    I = hm.get_implausibility(np.array([1., 1.]))
+
+    assert_allclose(I, [1./np.sqrt(2.), 1./np.sqrt(2.)])
+    assert_allclose(hm.I, [1./np.sqrt(2.), 1./np.sqrt(2.)])
+
+    np.random.seed(57483)
+    gp = fit_GP_MAP(np.reshape(np.linspace(0., 1.), (-1, 1)), [np.linspace(0., 1.), np.linspace(0., 1.)**2])
+    coords = np.array([[0.1], [1.]])
+    obs = [np.array([1., 5.]), np.array([0.01, 0.01])]
+    mean, unc, _ = gp.predict(coords)
+    I_exp = np.abs(mean - obs[0][:, np.newaxis])/np.sqrt(unc + obs[1][:,np.newaxis])
+    I_exp = I_exp[np.where(np.argsort(I_exp, axis=0) == 1)]
+
+    hm = HistoryMatching(gp=gp, obs=obs, coords=coords)
+    I = hm.get_implausibility(rank=0)
+
+    assert_allclose(I, I_exp)
+    assert_allclose(hm.I, I_exp)
+    
+    np.random.seed(57483)
+    gp = fit_GP_MAP(np.reshape(np.linspace(0., 1.), (-1, 1)), [np.linspace(0., 1.),
+                                                               np.linspace(0., 1.)**2,
+                                                               np.linspace(0., 1.)**3])
+    coords = np.array([[0.1], [1.]])
+    obs = [np.array([1., 5., 4.]), np.array([0.01, 0.01, 0.01])]
+    mean, unc, _ = gp.predict(coords)
+    I_exp = np.abs(mean - obs[0][:, np.newaxis])/np.sqrt(unc + obs[1][:,np.newaxis])
+    I_exp = I_exp[np.where(np.argsort(I_exp, axis=0) == 0)]
+
+    hm = HistoryMatching(gp=gp, obs=obs, coords=coords)
+    I = hm.get_implausibility(rank=2)
+
+    assert_allclose(I, I_exp)
+    assert_allclose(hm.I, I_exp)
+
 def test_HistoryMatching_get_NROY():
     "test the get_NROY method of HistoryMatching"
 
@@ -456,6 +510,14 @@ def test_HistoryMatching_set_gp():
     hm.set_gp(gp)
 
     assert hm.gp == gp
+    
+    gp = MultiOutputGP(np.reshape(np.linspace(0., 1.), (-1, 1)), [np.linspace(0., 1.),
+                                                                  np.linspace(0., 1.)**2])
+    
+    hm = HistoryMatching()
+    hm.set_gp(gp)
+
+    assert hm.gp == gp
 
     # bad type for GP
 
@@ -491,12 +553,28 @@ def test_HistoryMatching_set_obs():
     hm = HistoryMatching()
     hm.set_obs(obs)
 
-    assert_allclose(hm.obs, obs)
+    assert_allclose(hm.obs, np.reshape(obs, (-1, 1)))
 
     obs = 1.
     hm.set_obs(obs)
 
-    assert_allclose(hm.obs, [obs, 0.])
+    assert_allclose(hm.obs, [[obs], [0.]])
+    
+    obs = [np.array([1., 2.]), 2.]
+
+    hm = HistoryMatching()
+    hm.set_obs(obs)
+
+    assert_allclose(hm.obs[0], obs[0])
+    assert_allclose(hm.obs[1], obs[1])
+    
+    obs = [np.array([1., 2.]), np.array([2., 4.])]
+
+    hm = HistoryMatching()
+    hm.set_obs(obs)
+
+    assert_allclose(hm.obs[0], obs[0])
+    assert_allclose(hm.obs[1], obs[1])
 
     # wrong number of values for obs
 
@@ -512,6 +590,11 @@ def test_HistoryMatching_set_obs():
 
     with pytest.raises(TypeError):
         hm.set_obs("abc")
+        
+    # array with wrong first dimension size
+    
+    with pytest.raises(AssertionError):
+        hm.set_obs(np.ones((3, 2)))
 
 def test_HistoryMatching_set_coords():
     "test the set_coords method of HistoryMatching"

--- a/mogp_emulator/tests/test_HistoryMatching.py
+++ b/mogp_emulator/tests/test_HistoryMatching.py
@@ -433,13 +433,13 @@ def test_HistoryMatching_get_implausibility_mogp():
     obs = [np.array([1., 5.]), np.array([0.01, 0.01])]
     mean, unc, _ = gp.predict(coords)
     I_exp = np.abs(mean - obs[0][:, np.newaxis])/np.sqrt(unc + obs[1][:,np.newaxis])
-    I_exp = I_exp[np.where(np.argsort(I_exp, axis=0) == 1)]
+    I_exp2 = [np.max(x) for x in I_exp.T]
 
     hm = HistoryMatching(gp=gp, obs=obs, coords=coords)
     I = hm.get_implausibility(rank=0)
 
-    assert_allclose(I, I_exp)
-    assert_allclose(hm.I, I_exp)
+    assert_allclose(I, I_exp2)
+    assert_allclose(hm.I, I_exp2)
     
     np.random.seed(57483)
     gp = fit_GP_MAP(np.reshape(np.linspace(0., 1.), (-1, 1)), [np.linspace(0., 1.),
@@ -449,13 +449,13 @@ def test_HistoryMatching_get_implausibility_mogp():
     obs = [np.array([1., 5., 4.]), np.array([0.01, 0.01, 0.01])]
     mean, unc, _ = gp.predict(coords)
     I_exp = np.abs(mean - obs[0][:, np.newaxis])/np.sqrt(unc + obs[1][:,np.newaxis])
-    I_exp = I_exp[np.where(np.argsort(I_exp, axis=0) == 0)]
+    I_exp2 = [np.min(x) for x in I_exp.T]
 
     hm = HistoryMatching(gp=gp, obs=obs, coords=coords)
     I = hm.get_implausibility(rank=2)
 
-    assert_allclose(I, I_exp)
-    assert_allclose(hm.I, I_exp)
+    assert_allclose(I, I_exp2)
+    assert_allclose(hm.I, I_exp2)
 
 def test_HistoryMatching_get_NROY():
     "test the get_NROY method of HistoryMatching"


### PR DESCRIPTION
Adds support for multiple output history matching. Addresses #113 and #195.

New in this PR:

- `HistoryMatching` class now accepts vector observations and multi-output GPs.
- Unit tests for the new functionality.
- New example demo script for multiple outputs building on the projectile simulation.