### PR TITLE
v0.6.1

### DIFF
--- a/mogp_emulator/GaussianProcess.py
+++ b/mogp_emulator/GaussianProcess.py
@@ -503,7 +503,7 @@ class GaussianProcess(GaussianProcessBase):
             dm = np.ones((inputs.shape[0], 1))
         else:
             try:
-                dm = dmatrix(self._mean, data={"x": inputs.T})
+                dm = np.array(dmatrix(self._mean, data={"x": inputs.T}))
             except PatsyError:
                 raise ValueError("Provided mean function is invalid")
             if not dm.shape[0] == inputs.shape[0]:

--- a/mogp_emulator/GaussianProcess.py
+++ b/mogp_emulator/GaussianProcess.py
@@ -658,6 +658,8 @@ class GaussianProcess(GaussianProcessBase):
         
         self.theta.mean = calc_mean_params(self.Ainv, self.Kinv_t,
                                            self._dm, self.priors.mean)
+                                           
+        self.Kinv_t_mean = self.Kinv.solve(self.targets - np.dot(self._dm, self.theta.mean))
 
         if self.priors.mean.has_weak_priors:
             n_coeff = self.n - self.n_mean
@@ -874,7 +876,7 @@ class GaussianProcess(GaussianProcessBase):
         mtest = np.dot(dmtest, self.theta.mean)
         Ktest = self.get_cov_matrix(testing)
 
-        mu = mtest + np.dot(Ktest.T, self.Kinv_t)
+        mu = mtest + np.dot(Ktest.T, self.Kinv_t_mean)
 
         var = None
         if unc:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import numpy as np
 # version information
 MAJOR = 0
 MINOR = 6
-MICRO = 0
+MICRO = 1
 PRERELEASE = 0
 ISRELEASED = True
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)


### PR DESCRIPTION
Bug fix release correcting #217 and #219.

- Corrects problem where predictions were not done correctly with a mean function. New unit tests were written that caught this error and can confirm the functionality is now correct.
- Fixes issues with `patsy` objects not supporting pickling for use with Multiple Outputs. Design matrices are converted back to numpy arrays so that they can be pickled, and warnings are given that using a patsy model description as a mean function does not support parallel fitting/prediction (and falls back to serial prediction). 