### PR TITLE
MOGP methods to match GPU

### DIFF
--- a/mogp_emulator/MultiOutputGP_GPU.py
+++ b/mogp_emulator/MultiOutputGP_GPU.py
@@ -5,13 +5,14 @@ from mogp_emulator.GaussianProcess import (
     GaussianProcess,
     PredictResult
 )
+from mogp_emulator.MultiOutputGP import MultiOutputGPBase
 from mogp_emulator.GaussianProcessGPU import GaussianProcessGPU, parse_meanfunc_formula
 from mogp_emulator.MeanFunction import MeanBase
 from mogp_emulator.Kernel import SquaredExponential, Matern52
 from mogp_emulator import LibGPGPU
 
 
-class MultiOutputGP_GPU(object):
+class MultiOutputGP_GPU(MultiOutputGPBase):
     """Implementation of a multiple-output Gaussian Process Emulator, using the GPU.
 
     Essentially a parallelized wrapper for the predict method. To fit

--- a/mogp_emulator/tests/test_MultiOutputGP.py
+++ b/mogp_emulator/tests/test_MultiOutputGP.py
@@ -138,7 +138,7 @@ def test_MultiOutputGP_GPU_predict(x, y, dx):
     "test the predict method of GaussianProcess"
 
     gp = MultiOutputGP_GPU(x, y, nugget=0.)
-    theta = np.ones(gp.n_params)
+    theta = np.ones(gp.n_params[0])
 
     gp.fit_emulator(0,theta)
     gp.fit_emulator(1,theta)
@@ -160,7 +160,7 @@ def test_MultiOutputGP_GPU_predict(x, y, dx):
 
     nugget = 1.
     gp = MultiOutputGP_GPU(x, y, nugget=nugget)
-    theta = np.ones(gp.n_params)
+    theta = np.ones(gp.n_params[0])
 
     gp.fit_emulator(0,theta)
     gp.fit_emulator(1,theta)
@@ -228,7 +228,7 @@ def test_MultiOutputGP_GPU_check(x, y):
     """
 
     gp = MultiOutputGP_GPU(x, y, nugget=0.)
-    theta = np.ones(gp.n_params)
+    theta = np.ones(gp.n_params[0])
 
     assert gp.get_indices_fit() == []
     assert gp.get_indices_not_fit() == [0, 1]

--- a/mogp_emulator/tests/test_MultiOutputGP.py
+++ b/mogp_emulator/tests/test_MultiOutputGP.py
@@ -24,13 +24,12 @@ def test_MultiOutputGP_init(x, y):
     "Test function for correct functioning of the init method of GaussianProcess"
 
     gp = MultiOutputGP(x, y)
-    assert_allclose(x, gp.emulators[0].inputs)
-    assert_allclose(x, gp.emulators[1].inputs)
-    assert_allclose(y[0], gp.emulators[0].targets)
-    assert_allclose(y[1], gp.emulators[1].targets)
+    assert_allclose(x, gp.inputs)
+    assert_allclose(y, gp.targets)
     assert gp.D == 3
     assert gp.n == 2
     assert gp.n_emulators == 2
+    assert gp.n_params == [4, 4]
     
     gp = MultiOutputGP(x, y, mean="1")
     gp = MultiOutputGP(x, y, mean=["1", "x[0]"])
@@ -63,10 +62,9 @@ def test_MultiOutputGP_predict(x, y, dx):
     "test the predict method of GaussianProcess"
 
     gp = MultiOutputGP(x, y, nugget=0.)
-    theta = np.ones(gp.emulators[0].n_params)
+    thetas = [np.ones((n,)) for n in gp.n_params]
 
-    gp.emulators[0].fit(theta)
-    gp.emulators[1].fit(theta)
+    gp.fit(thetas)
 
     x_test = np.array([[2., 3., 4.]])
 
@@ -74,27 +72,30 @@ def test_MultiOutputGP_predict(x, y, dx):
 
     for i in range(2):
 
-        K = np.exp(theta[-1])*gp.emulators[i].kernel.kernel_f(x, x, theta[:-1])
-        Ktest = np.exp(theta[-1])*gp.emulators[i].kernel.kernel_f(x_test, x, theta[:-1])
+        K = np.exp(thetas[i][-1])*gp.emulators[i].kernel.kernel_f(x, x, thetas[i][:-1])
+        Ktest = np.exp(thetas[i][-1])*gp.emulators[i].kernel.kernel_f(x_test, x, thetas[i][:-1])
 
         mu_expect = np.dot(Ktest, gp.emulators[i].Kinv_t)
-        var_expect = np.exp(theta[-1]) - np.diag(np.dot(Ktest, np.linalg.solve(K, Ktest.T)))
+        var_expect = np.exp(thetas[i][-1]) - np.diag(np.dot(Ktest, np.linalg.solve(K, Ktest.T)))
 
         assert_allclose(mu[i], mu_expect)
         assert_allclose(var[i], var_expect)
+        
+    gp.reset_fit_status()
 
     nugget = 1.
     gp = MultiOutputGP(x, y, nugget=nugget)
-    theta = np.ones(gp.emulators[0].n_params)
+    theta0 = np.ones(gp.emulators[0].n_params)
+    theta1 = np.ones(gp.emulators[1].n_params)
 
-    gp.emulators[0].fit(theta)
-    gp.emulators[1].fit(theta)
+    gp.fit_emulator(0, theta0)
+    gp.fit_emulator(1, theta1)
 
     x_test = np.array([[2., 3., 4.]])
 
     mu, var, deriv = gp.predict(x_test)
 
-    for i in range(2):
+    for i, theta in zip(range(2), [theta0, theta1]):
 
         K = np.exp(theta[-1])*gp.emulators[i].kernel.kernel_f(x, x, theta[:-1]) + np.eye(gp.emulators[i].n)*nugget
         Ktest = np.exp(theta[-1])*gp.emulators[i].kernel.kernel_f(x_test, x, theta[:-1])

--- a/mogp_gpu/src/multioutputgp_gpu.hpp
+++ b/mogp_gpu/src/multioutputgp_gpu.hpp
@@ -92,11 +92,12 @@ public:
         return emulators.size();
     }
 
-    int get_n_data_params(void) const
+    std::vector<unsigned int> get_n_data_params(void) const
     {   
-        if (emulators.size() > 0)
-            return emulators[0]->get_n_params();
-        return 0;
+        std::vector<unsigned int> n_params;
+        for (unsigned int i=0; i< emulators.size(); ++i) 
+            n_params.push_back(emulators[i]->get_n_params());
+        return n_params;
     }
 
     void reset_fit_status(void) {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import numpy as np
 MAJOR = 0
 MINOR = 7
 MICRO = 0
-PRERELEASE = 3
+PRERELEASE = 4
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Matches the public Multi-Output interface defined in the GPU class in ``MultiOutputGP_GPU.py``. Mostly this is a convenience interface, though I needed to add the ``_process_inputs`` to allow validation routines to check the inputs for both the GP and MOGP classes (however this is not a public method so the public interface should match). Addresses #207.

New in this PR:
- Additional interface methods to match the GPU class. Also adds a base class for consistency with the GP implementation.
- Tests that ensure the functionality works as expected.
