### PR TITLE
updated ubuntu and python versions in travis build to fix problem wit…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
+dist: focal
 python:
-  - "3.7"
+  - "3.9"
 install:
   - pip install 'numpy>=1.19'
   - pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import numpy as np
 MAJOR = 0
 MINOR = 7
 MICRO = 0
-PRERELEASE = 2
+PRERELEASE = 3
 ISRELEASED = False
 version = "{}.{}.{}".format(MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Bumps the Ubuntu and Python version for CI testing due to a non-backwards compatible change in setuptools. Addresses #227.

- Update Travis file to use more recent Python and Ubuntu versions