### PR TITLE
remove the old .so file from build area when installing GPU implementation via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import setuptools
 
 from distutils.extension import Extension
 from distutils.command.build_ext import build_ext
+from distutils.command.clean import clean
 
 import numpy as np
 
@@ -105,6 +106,13 @@ def find_dlib():
         "lib64": lib64
     }
 
+def clean_build_area(self):
+    # clean the current build area
+    c = clean(self.distribution)
+    c.all = True
+    c.finalize_options()
+    c.run()
+
 
 def customize_compiler_for_nvcc(self):
     """
@@ -140,6 +148,7 @@ def customize_compiler_for_nvcc(self):
 # Run the custom compiler
 class custom_build_ext(build_ext):
     def build_extensions(self):
+        clean_build_area(self)
         customize_compiler_for_nvcc(self.compiler)
         build_ext.build_extensions(self)
 


### PR DESCRIPTION
While investigating something else I found that the behaviour of `pip install .` has changed - it builds the library in a local `build` directory before copying it to `site-packages`.   This was not being rebuilt after changing the code.
This change to `setup.py` cleans the existing library, so it is rebuilt every time.