### PR TITLE
Reduce memory usage in gKDR

### DIFF
--- a/mogp_emulator/DimensionReduction.py
+++ b/mogp_emulator/DimensionReduction.py
@@ -71,6 +71,7 @@ regression on the reduced input space:
 import sys
 import numpy as np
 from scipy.spatial.distance import cdist, pdist, squareform
+from scipy.linalg import cho_solve, cholesky
 from mogp_emulator.utils import k_fold_cross_validation, integer_bisect
 
 def gram_matrix(X, k):
@@ -199,8 +200,10 @@ class gKDR(object):
         Kx = gram_matrix_sqexp(X, SGX2)
         Ky = gram_matrix_sqexp(Y, SGY2)
 
-        tmp = np.linalg.solve(Kx + N*EPS*I, Ky)
-        F = np.linalg.solve((Kx + N*EPS*I).T, tmp.T).T
+        regularized_Kx = Kx + N*EPS*I
+        lower_chol_factor = cholesky(regularized_Kx, lower=True)
+        tmp = cho_solve((lower_chol_factor, True), Ky)
+        F = cho_solve((lower_chol_factor, True), tmp.T).T
 
         Dx = np.reshape(np.tile(X,(N,1)), (N,N,M), order='F').copy()
         Xij = Dx - np.transpose(Dx, (1,0,2))

--- a/mogp_emulator/tests/test_DimensionReduction.py
+++ b/mogp_emulator/tests/test_DimensionReduction.py
@@ -124,6 +124,14 @@ def test_DimensionReduction_gram_matrix():
 
 
 def test_DimensionReduction_large():
+    """Check that gKDR runs on a 'large' problem
+
+    The implementation of gKDR in mogp v0.7 and earlier did not scale
+    well with problem size.  This test is of a larger case than could
+    reasonably be handled by that implementation, but should cause no
+    issue for the current one.  The check is simply that the function
+    completes without a crash or error.
+    """
     X = np.random.randn(200, 3200)
     Y = np.arange(200)
 

--- a/mogp_emulator/tests/test_DimensionReduction.py
+++ b/mogp_emulator/tests/test_DimensionReduction.py
@@ -121,3 +121,10 @@ def test_DimensionReduction_gram_matrix():
 
     assert(np.allclose(G_sqexp1, G_sqexp_expected))
     assert(np.allclose(G_sqexp2, G_sqexp_expected))
+
+
+def test_DimensionReduction_large():
+    X = np.random.randn(200, 3200)
+    Y = np.arange(200)
+
+    dr = gKDR(X, Y, 2)

--- a/mogp_emulator/tests/test_DimensionReduction.py
+++ b/mogp_emulator/tests/test_DimensionReduction.py
@@ -132,7 +132,7 @@ def test_DimensionReduction_large():
     issue for the current one.  The check is simply that the function
     completes without a crash or error.
     """
-    X = np.random.randn(200, 3200)
+    X = np.eye(200, 3200)
     Y = np.arange(200)
 
     dr = gKDR(X, Y, 2)

--- a/mogp_emulator/tests/test_DimensionReduction.py
+++ b/mogp_emulator/tests/test_DimensionReduction.py
@@ -91,6 +91,8 @@ def test_DimensionReduction_B():
         assert(np.allclose(r, 1.0) or np.allclose(r, -1.0))
 
 def test_DimensionReduction_median_dist():
+    """Some basic checks of `mean_dist`
+    """
     X1 = np.array([[0.0], [1.0], [2.0]])
     assert(np.allclose(median_dist(X1), 1))
 
@@ -98,6 +100,8 @@ def test_DimensionReduction_median_dist():
     assert(np.allclose(median_dist(X2), 1.5))
 
 def test_DimensionReduction_gram_matrix():
+    """Some basic checks of `gram_matrix` and `gram_matrix_sqexp`
+    """
     X = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
     def k_dot(x0, x1):
         return np.dot(x0, x1)


### PR DESCRIPTION
Fixes #242.

The current implementation of gKDR exclusively uses array computations. A drawback of this is that there are some large temporary arrays created (the largest having size `N^2 M^2` where `N` is the number of observations and `M` is the number of features).

This PR replaces one of these array computations with an explicit loop, reducing the space used to `O(M^2 + M N^2)`.

It also replaces two calls to `np.linalg.solve` with calls to `cho_solve` (and a single Cholesky decomposition).

