### PR TITLE
Update documentation to reflect patsy requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ installed via `pip`:
 pip install mogp-emulator
 ```
 
-Optionally, you may want to install some additional optional packages. `matplotlib` is useful for
-visualising some of the results of the benchmarks, and `patsy` is highly recommended for users that
-wish to parse R-style string formulas for specifying mean functions. These can be found in the
+Optionally, you may want to install some additional packages. In particular, `matplotlib` is useful for
+visualising some of the results of the benchmarks. These can be found in the
 [requirements-optional.txt](requirements-optional.txt) file in the main repository.
+
+Additionally, packages used in testing and developing the code base are listed in
+[requirements-dev.txt](requirements-dev.txt).
 
 ## Documentation
 

--- a/docs/intro/installation.rst
+++ b/docs/intro/installation.rst
@@ -44,16 +44,14 @@ available.
 Requirements
 ~~~~~~~~~~~~
 
-The code requires Python 3.6 or later, and working Numpy and Scipy installations are required. You should
+The code requires Python 3.6 or later, and working Numpy, Scipy, and Patsy installations are required. You should
 be able to install these packages using ``pip`` if you do not have them already available on your system.
 From the base ``mogp_emulator`` directory, you can install all required packages using: ::
 
    pip install -r requirements.txt
 
 This will install the minimum requirements needed to use ``mogp_emulator``. There are a few addditional
-packages that are not required but can be useful (in particular, ``patsy`` is used for parsing
-mean functions using R-style formulas, so all R users are highly encouraged to install the optional
-dependencies). Installation of the optional dependencies can be done via: ::
+packages that are not required but can be useful. Installation of the optional dependencies can be done via: ::
 
    pip install -r requirements-optional.txt
 


### PR DESCRIPTION
A previous major upgrade added patsy as a requirement rather than an optional dependency. The documentation (readme and installation page on the sphinx docs) now have been updated to reflect this. Fixes #233 and #241.

Changes in this PR:

- Update to `README.md`
- Update to `docs/intro/installation.rst`