### PR TITLE
Fix scipy version check

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,7 +56,7 @@ details, and some included benchmarks.
 
 .. toctree::
    :maxdepth: 1
-   :caption: For some more speicifs on benchmarks involving the implementation, see the following benchmark examples:
+   :caption: For some more specifics on benchmarks involving the implementation, see the following benchmark examples:
 
    benchmarks/benchmarks
 

--- a/docs/intro/tutorial.rst
+++ b/docs/intro/tutorial.rst
@@ -166,7 +166,7 @@ and the uncertainty. This is done with the ``predict`` method of
 .. literalinclude:: ../../mogp_emulator/demos/tutorial.py
    :lines: 46-55
 
-``predictions`` is an object containing the mean and uncertainty (variance)
+The output of ``predict`` is an object containing the mean and uncertainty (variance)
 of the predictions. A GP assumes that the outputs follow a Normal Distribution,
 so we can perform validation by asking how many of our validation points mean estimates
 are within 2 standard deviations of the true value by computing the standard errors

--- a/mogp_emulator/demos/projectile.py
+++ b/mogp_emulator/demos/projectile.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy
 from scipy.integrate import solve_ivp
 
-assert scipy.__version__ >= '1.4', "projectile.py requires scipy version 1.4 or greater"
+assert tuple(map(int, scipy.__version__.split('.'))) >= (1, 4), "projectile.py requires scipy version 1.4 or greater"
 
 # Create our simulator, which solves a nonlinear differential equation describing projectile
 # motion with drag. A projectile is launched from an initial height of 2 meters at an


### PR DESCRIPTION
* Importing `simulator` from `mogp_emulator.demos.projectile` fails because scipy versions >= 1.10 evaluate to `False` when compared to '1.4' using string comparison. This is now fixed using `map`.
* Also some small fixes to the tutorial.